### PR TITLE
run the encoding on start and end in case your keys are JSON encoded

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -36,11 +36,12 @@ function ReadStream (options, db, iteratorFactory) {
   // purely to keep `db` around until we're done so it's not GCed if the user doesn't keep a ref
   this._db = db
 
-  this._options = extend(extend({}, defaultOptions), options)
+  options = this._options = extend(extend({}, defaultOptions), options)
+  var keyEncoding = options.keyEncoding || options.encoding
   if (typeof this._options.start !== 'undefined')
-    this._options.start = toBuffer(this._options.start)
+    this._options.start = toBuffer(this._options.start, keyEncoding)
   if (typeof this._options.end !== 'undefined')
-    this._options.end = toBuffer(this._options.end)
+    this._options.end = toBuffer(this._options.end, keyEncoding)
 
   this._makeData = this._options.keys && this._options.values
     ? makeKeyValueData.bind(this) : this._options.keys


### PR DESCRIPTION
otherwise the start and end don't work!
