### PR TITLE
use util.inherits() from node core

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -1,6 +1,8 @@
 /* Copyright (c) 2012 Rod Vagg <@rvagg> */
 
 var bridge       = require('bindings')('levelup.node')
+  , EventEmitter = require('events').EventEmitter
+  , inherits     = require('util').inherits
 
   , errors       = require('./errors')
   , readStream   = require('./read-stream')
@@ -9,7 +11,6 @@ var bridge       = require('bindings')('levelup.node')
   , toSlice      = require('./util').toSlice
   , extend       = require('./util').extend
   , encodings    = require('./util').encodings
-  , EventEmitter = require('events').EventEmitter
 
   , defaultOptions = {
         createIfMissing : false
@@ -45,7 +46,6 @@ var bridge       = require('bindings')('levelup.node')
 //                except for another open() operation
 
 function LevelUP (location, options) {
-  this.__proto__.__proto__ = EventEmitter.prototype
   EventEmitter.call(this)
   this.setMaxListeners(Infinity)
   
@@ -54,286 +54,286 @@ function LevelUP (location, options) {
   this._status = 'new'
 }
 
-LevelUP.prototype = {
-    open: function (callback) {
-      this._status = 'opening'
-      var execute = function () {
-        var db = bridge.createDatabase()
-        db.open(this._location, this._options, function (err) {
-          if (err) {
-            err = new errors.OpenError(err)
-            if (callback)
-              return callback(err)
-            this.emit('error', err)
-          } else {
-            this._db = db
-            this._status = 'open'
-            callback && callback(null, this)
-            this.emit('ready')
-          }
-        }.bind(this))
-      }.bind(this)
+inherits(LevelUP, EventEmitter)
 
-      if (this.isOpen())
-        this.close(execute)
-      else
-        execute()
-    }
-
-    //TODO: we can crash Node by submitting an operation between close() and the actual closing of the database
-  , close: function (callback) {
-      if (this.isOpen()) {
-        this._status = 'closing'
-        this._db.close(function () {
-          this._status = 'closed'
-          this.emit('closed')
-          callback && callback.apply(null, arguments)
-        }.bind(this))
-        this._db = null
-      } else if (this._status == 'closed') {
-        callback && callback()
-      } else if (this._status == 'closing') {
-        this.on('closed', callback)
-      } else if (this._status == 'opening') {
-        this.on('ready', function () {
-          this.close(callback)
-        })
+LevelUP.prototype.open = function (callback) {
+  this._status = 'opening'
+  var execute = function () {
+    var db = bridge.createDatabase()
+    db.open(this._location, this._options, function (err) {
+      if (err) {
+        err = new errors.OpenError(err)
+        if (callback)
+          return callback(err)
+        this.emit('error', err)
       } else {
-        var err = new errors.CloseError('Cannot close unopened database')
+        this._db = db
+        this._status = 'open'
+        callback && callback(null, this)
+        this.emit('ready')
+      }
+    }.bind(this))
+  }.bind(this)
+  
+  if (this.isOpen())
+    this.close(execute)
+  else
+    execute()
+}
+
+//TODO: we can crash Node by submitting an operation between close() and the actual closing of the database
+LevelUP.prototype.close = function (callback) {
+  if (this.isOpen()) {
+    this._status = 'closing'
+    this._db.close(function () {
+      this._status = 'closed'
+      this.emit('closed')
+      callback && callback.apply(null, arguments)
+    }.bind(this))
+    this._db = null
+  } else if (this._status == 'closed') {
+    callback && callback()
+  } else if (this._status == 'closing') {
+    this.on('closed', callback)
+  } else if (this._status == 'opening') {
+    this.on('ready', function () {
+      this.close(callback)
+    })
+  } else {
+    var err = new errors.CloseError('Cannot close unopened database')
+    if (callback)
+      return callback(err)
+    throw err
+  }
+}
+
+LevelUP.prototype.isOpen = function () {
+  return this._status == 'open'
+}
+
+// in between these two there is 'new' and 'opening'
+
+LevelUP.prototype.isClosed = function () {
+  // covers 'closing' and 'closed'
+  return (/^clos/).test(this._status)
+}
+
+LevelUP.prototype.get = function (key_, options_, callback_) {
+  var open = this.isOpen()
+  , callback, options, key, keyEnc, valueEnc, err
+  
+  if (!open && !this.isClosed()) {
+    // limbo, defer the operation
+    return this.once('ready', function () {
+      this.get(key_, options_, callback_)
+    })
+  }
+  
+  callback = getCallback(options_, callback_)
+  
+  if (open) {
+    options  = getOptions(options_, this._options)
+    keyEnc   = options.keyEncoding   || options.encoding
+    valueEnc = options.valueEncoding || options.encoding
+    key      = toSlice[keyEnc](key_)
+    options.asBuffer = valueEnc != 'utf8' && valueEnc != 'json'
+    this._db.get(key, options, function (err, value) {
+      if (err) {
+        err = new errors.NotFoundError('Key not found in database [' + key_ + ']')
         if (callback)
           return callback(err)
         throw err
       }
-    }
+      callback && callback(null, toEncoding[valueEnc](value), key_)
+    })
+  } else {
+    err = new errors.ReadError('Database is not open')
+    if (callback)
+      return callback(err)
+    throw err
+  }
+}
 
-  , isOpen: function () {
-      return this._status == 'open'
-    }
-
-    // in between these two there is 'new' and 'opening'
-
-  , isClosed: function () {
-      // covers 'closing' and 'closed'
-      return (/^clos/).test(this._status)
-    }
-
-  , get: function (key_, options_, callback_) {
-      var open = this.isOpen()
-        , callback, options, key, keyEnc, valueEnc, err
-
-      if (!open && !this.isClosed()) {
-        // limbo, defer the operation
-        return this.once('ready', function () {
-          this.get(key_, options_, callback_)
-        })
-      }
-
-      callback = getCallback(options_, callback_)
-
-      if (open) {
-        options  = getOptions(options_, this._options)
-        keyEnc   = options.keyEncoding   || options.encoding
-        valueEnc = options.valueEncoding || options.encoding
-        key      = toSlice[keyEnc](key_)
-        options.asBuffer = valueEnc != 'utf8' && valueEnc != 'json'
-        this._db.get(key, options, function (err, value) {
-          if (err) {
-            err = new errors.NotFoundError('Key not found in database [' + key_ + ']')
-            if (callback)
-              return callback(err)
-            throw err
-          }
-          callback && callback(null, toEncoding[valueEnc](value), key_)
-        })
+LevelUP.prototype.put = function (key_, value_, options_, callback_) {
+  var open = this.isOpen()
+  , callback, options, err, key, value
+  
+  if (!open && !this.isClosed()) {
+    // limbo, defer the operation
+    return this.once('ready', function () {
+      this.put(key_, value_, options_, callback_)
+    })
+  }
+  
+  callback = getCallback(options_, callback_)
+  
+  if (open) {
+    options  = getOptions(options_, this._options)
+    key      = toSlice[options.keyEncoding   || options.encoding](key_)
+    value    = toSlice[options.valueEncoding || options.encoding](value_)
+    this._db.put(key, value, options, function (err) {
+      if (err) {
+        err = new errors.WriteError(err)
+        if (callback)
+          return callback(err)
+        this.emit('error', err)
       } else {
-        err = new errors.ReadError('Database is not open')
+        this.emit('put', key_, value_)
+        callback && callback(null, key, value)
+      }
+    }.bind(this))
+  } else {
+    err = new errors.WriteError('Database is not open')
+    if (callback)
+      return callback(err)
+    throw err
+  }
+}
+
+LevelUP.prototype.del = function (key_, options_, callback_) {
+  var open, callback, options, err, key
+  
+  if (!(open = this.isOpen()) && !this.isClosed()) {
+    // limbo, defer the operation
+    return this.once('ready', function () {
+      this.del(key_, options_, callback_)
+    })
+  }
+  
+  callback = getCallback(options_, callback_)
+  
+  if (open) {
+    options  = getOptions(options_, this._options)
+    key      = toSlice[options.keyEncoding   || options.encoding](key_)
+    this._db.del(key, options, function (err) {
+      if (err) {
+        err = new errors.WriteError(err)
         if (callback)
           return callback(err)
-        throw err
-      }
-    }
-
-  , put: function (key_, value_, options_, callback_) {
-      var open = this.isOpen()
-        , callback, options, err, key, value
-
-      if (!open && !this.isClosed()) {
-        // limbo, defer the operation
-        return this.once('ready', function () {
-          this.put(key_, value_, options_, callback_)
-        })
-      }
-
-      callback = getCallback(options_, callback_)
-
-      if (open) {
-        options  = getOptions(options_, this._options)
-        key      = toSlice[options.keyEncoding   || options.encoding](key_)
-        value    = toSlice[options.valueEncoding || options.encoding](value_)
-        this._db.put(key, value, options, function (err) {
-          if (err) {
-            err = new errors.WriteError(err)
-            if (callback)
-              return callback(err)
-            this.emit('error', err)
-          } else {
-            this.emit('put', key_, value_)
-            callback && callback(null, key, value)
-          }
-        }.bind(this))
+        this.emit('error', err)
       } else {
-        err = new errors.WriteError('Database is not open')
-        if (callback)
-          return callback(err)
-        throw err
+        this.emit('del', key_)
+        callback && callback(null, key)
       }
-    }
+    }.bind(this))
+  } else {
+    err = new errors.WriteError('Database is not open')
+    if (callback)
+      return callback(err)
+    throw err
+  }
+}
 
-  , del: function (key_, options_, callback_) {
-      var open, callback, options, err, key
-
-      if (!(open = this.isOpen()) && !this.isClosed()) {
-        // limbo, defer the operation
-        return this.once('ready', function () {
-          this.del(key_, options_, callback_)
-        })
-      }
-
-      callback = getCallback(options_, callback_)
-
-      if (open) {
-        options  = getOptions(options_, this._options)
-        key      = toSlice[options.keyEncoding   || options.encoding](key_)
-        this._db.del(key, options, function (err) {
-          if (err) {
-            err = new errors.WriteError(err)
-            if (callback)
-              return callback(err)
-            this.emit('error', err)
-          } else {
-            this.emit('del', key_)
-            callback && callback(null, key)
-          }
-        }.bind(this))
-      } else {
-        err = new errors.WriteError('Database is not open')
-        if (callback)
-          return callback(err)
-        throw err
-      }
-    }
-
-  , batch: function (arr_, options_, callback_) {
-      var callback, options, keyEncoding, valueEncoding, err, arr
-
-      if (!this.isOpen() && !this.isClosed()) {
-        return this.once('ready', function () {
-          this.batch(arr_, options_, callback_)
-        })
-      }
-
-      callback = getCallback(options_, callback_)
-
-      if (this.isClosed()) {
-        err = new errors.WriteError('Database is not open')
-        if (callback)
-          return callback(err)
-        throw err
-      }
-
-      options       = getOptions(options_, this._options)
-      keyEncoding   = options.keyEncoding   || options.encoding
-      valueEncoding = options.valueEncoding || options.encoding
-
-      // If we're not dealing with plain utf8 strings or plain
-      // Buffers then we have to do some work on the array to
-      // encode the keys and/or values. This includes JSON types.
-      if ((keyEncoding != 'utf8' && keyEncoding != 'binary')
-          || (valueEncoding != 'utf8' && valueEncoding != 'binary')) {
-        arr = arr_.map(function (e) {
-          if (e.type !== undefined && e.key !== undefined) {
-            var o = {
-                type  : e.type
-              , key   : toSlice[keyEncoding](e.key)
-            }
-            if (e.value !== undefined)
-              o.value = toSlice[valueEncoding](e.value)
-            return o
-          }
-          return {}
-        })
-      } else
-        arr = arr_
-      this._db.batch(arr, options, function (err) {
-        if (err) {
-          err = new errors.WriteError(err)
-          if (callback)
-            return callback(err)
-          this.emit('error', err)
-        } else {
-          this.emit('batch', arr_)
-          callback && callback(null, arr)
+LevelUP.prototype.batch = function (arr_, options_, callback_) {
+  var callback, options, keyEncoding, valueEncoding, err, arr
+  
+  if (!this.isOpen() && !this.isClosed()) {
+    return this.once('ready', function () {
+      this.batch(arr_, options_, callback_)
+    })
+  }
+  
+  callback = getCallback(options_, callback_)
+  
+  if (this.isClosed()) {
+    err = new errors.WriteError('Database is not open')
+    if (callback)
+      return callback(err)
+    throw err
+  }
+  
+  options       = getOptions(options_, this._options)
+  keyEncoding   = options.keyEncoding   || options.encoding
+  valueEncoding = options.valueEncoding || options.encoding
+  
+  // If we're not dealing with plain utf8 strings or plain
+  // Buffers then we have to do some work on the array to
+  // encode the keys and/or values. This includes JSON types.
+  if ((keyEncoding != 'utf8' && keyEncoding != 'binary')
+      || (valueEncoding != 'utf8' && valueEncoding != 'binary')) {
+    arr = arr_.map(function (e) {
+      if (e.type !== undefined && e.key !== undefined) {
+        var o = {
+          type  : e.type
+          , key   : toSlice[keyEncoding](e.key)
         }
-      }.bind(this))
-    }
-
-  , approximateSize: function(start, end, callback) {
-      var err
-
-      if (!this.isOpen() && !this.isClosed()) {
-        return this.once('ready', function () {
-          this.approximateSize(start, end, callback)
-        })
+        if (e.value !== undefined)
+          o.value = toSlice[valueEncoding](e.value)
+        return o
       }
-
-      if (this.isClosed()) {
-        err = new errors.WriteError('Database is not open')
-        if (callback)
-          return callback(err)
-        throw err
-      }
-
-      this._db.approximateSize(start, end, function(err, size) {
-        if (err) {
-          err = new errors.OpenError(err)
-          if (callback)
-            return callback(err)
-          this.emit('error', err)
-        } else {
-          callback && callback(null, size)
-        }
-      });
+      return {}
+    })
+  } else
+    arr = arr_
+  this._db.batch(arr, options, function (err) {
+    if (err) {
+      err = new errors.WriteError(err)
+      if (callback)
+        return callback(err)
+      this.emit('error', err)
+    } else {
+      this.emit('batch', arr_)
+      callback && callback(null, arr)
     }
+  }.bind(this))
+}
 
-  , readStream: function (options) {
-      options = extend(extend({}, this._options), typeof options == 'object' ? options : {})
-      return readStream.create(
-          options
-        , this
-        , function (options) {
-            return bridge.createIterator(this._db, options)
-          }.bind(this)
-      )
-    }
+LevelUP.prototype.approximateSize = function(start, end, callback) {
+  var err
 
-  , keyStream: function (options) {
-      return this.readStream(extend(options ? extend({}, options) : {}, { keys: true, values: false }))
-    }
+  if (!this.isOpen() && !this.isClosed()) {
+    return this.once('ready', function () {
+      this.approximateSize(start, end, callback)
+    })
+  }
 
-  , valueStream: function (options) {
-      return this.readStream(extend(options ? extend({}, options) : {}, { keys: false, values: true }))
-    }
+  if (this.isClosed()) {
+    err = new errors.WriteError('Database is not open')
+    if (callback)
+      return callback(err)
+    throw err
+  }
 
-  , writeStream: function (options) {
-     return writeStream.create(
-          options || {}
-        , this
-      )
+  this._db.approximateSize(start, end, function(err, size) {
+    if (err) {
+      err = new errors.OpenError(err)
+      if (callback)
+        return callback(err)
+      this.emit('error', err)
+    } else {
+      callback && callback(null, size)
     }
+  })
+}
 
-  , toString: function () {
-      return 'LevelUP'
-    }
+LevelUP.prototype.readStream = function (options) {
+  options = extend(extend({}, this._options), typeof options == 'object' ? options : {})
+  return readStream.create(
+    options
+    , this
+    , function (options) {
+      return bridge.createIterator(this._db, options)
+    }.bind(this)
+  )
+}
+
+LevelUP.prototype.keyStream = function (options) {
+  return this.readStream(extend(options ? extend({}, options) : {}, { keys: true, values: false }))
+}
+
+LevelUP.prototype.valueStream = function (options) {
+  return this.readStream(extend(options ? extend({}, options) : {}, { keys: false, values: true }))
+}
+
+LevelUP.prototype.writeStream = function (options) {
+  return writeStream.create(
+    options || {}
+    , this
+  )
+}
+
+LevelUP.prototype.toString = function () {
+  return 'LevelUP'
 }
 
 module.exports = function (location, options, callback) {

--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -2,6 +2,7 @@
 
 var Stream       = require('stream').Stream
   , BufferStream = require('bufferstream')
+  , inherits     = require('util').inherits
 
   , toEncoding   = require('./util').toEncoding
   , toSlice      = require('./util').toSlice
@@ -26,7 +27,6 @@ var Stream       = require('stream').Stream
 
 
 function ReadStream (options, db, iteratorFactory) {
-  this.__proto__.__proto__ = Stream.prototype
   Stream.call(this)
 
   this._status  = 'ready'
@@ -69,86 +69,86 @@ function ReadStream (options, db, iteratorFactory) {
     db.once('ready', ready)
 }
 
-ReadStream.prototype = {
-    destroy: function () {
-      this._status = 'destroyed'
-      this._cleanup()
-    }
+inherits(ReadStream, Stream)
 
-  , pause: function () {
-      if (this._status != 'ended' && !/\+paused$/.test(this._status)) {
-        this.emit('pause')
-        this._status += '+paused' // preserve existing status
+ReadStream.prototype.destroy = function () {
+  this._status = 'destroyed'
+  this._cleanup()
+}
+
+ReadStream.prototype.pause = function () {
+  if (this._status != 'ended' && !/\+paused$/.test(this._status)) {
+    this.emit('pause')
+    this._status += '+paused' // preserve existing status
+  }
+}
+
+ReadStream.prototype.resume = function () {
+  if (this._status != 'ended') {
+    this.emit('resume')
+    this._status = this._status.replace(/\+paused$/, '')
+    this._read()
+  }
+}
+
+ReadStream.prototype.pipe = function (dest) {
+  if (typeof dest.add == 'function' && this._options.type == 'fstream') {
+    this._dataEvent = 'entry'
+    this.on('entry', function (data) {
+      var entry = new BufferStream()
+      entry.path = data.key.toString()
+      entry.type = 'File'
+      entry.props = {
+        type: 'File'
+        , path: data.key.toString()
       }
-    }
-
-  , resume: function () {
-      if (this._status != 'ended') {
-        this.emit('resume')
-        this._status = this._status.replace(/\+paused$/, '')
-        this._read()
+      entry.once('data', process.nextTick.bind(null, entry.end.bind(entry)))
+      entry.pause()
+      if (dest.add(entry) === false) {
+        this.pause()
       }
-    }
+      entry.write(data.value)
+    }.bind(this))
+  }
+  return Stream.prototype.pipe.apply(this, arguments)
+}
 
-  , pipe: function (dest) {
-      if (typeof dest.add == 'function' && this._options.type == 'fstream') {
-        this._dataEvent = 'entry'
-        this.on('entry', function (data) {
-          var entry = new BufferStream()
-          entry.path = data.key.toString()
-          entry.type = 'File'
-          entry.props = {
-              type: 'File'
-            , path: data.key.toString()
-          }
-          entry.once('data', process.nextTick.bind(null, entry.end.bind(entry)))
-          entry.pause()
-          if (dest.add(entry) === false) {
-            this.pause()
-          }
-          entry.write(data.value)
-        }.bind(this))
-      }
-      return Stream.prototype.pipe.apply(this, arguments)
-    }
+ReadStream.prototype._read = function () {
+  if (this._status == 'ready') {
+    this._status = 'reading'
+    this._iterator.next(this._cleanup.bind(this), this._onData.bind(this))
+  }
+}
 
-  , _read: function () {
-      if (this._status == 'ready') {
-        this._status = 'reading'
-        this._iterator.next(this._cleanup.bind(this), this._onData.bind(this))
-      }
-    }
+ReadStream.prototype._onData = function (err, key, value) {
+  if (err)
+    return this._cleanup(err)
+  if (this._status == 'ended')
+    return
+  if (/^reading/.test(this._status))
+    this._status = this._status.replace(/^reading/, 'ready')
+  this._read()
+  this.emit(this._dataEvent, this._makeData(key, value))
+}
 
-  , _onData: function (err, key, value) {
-      if (err)
-        return this._cleanup(err)
-      if (this._status == 'ended')
-        return
-      if (/^reading/.test(this._status))
-        this._status = this._status.replace(/^reading/, 'ready')
-      this._read()
-      this.emit(this._dataEvent, this._makeData(key, value))
-    }
+ReadStream.prototype._cleanup = function (err) {
+  var s = this._status
+  this._status = 'ended'
+  this.readable = false
+  if (this._iterator) {
+    this._iterator.end(function () {
+      this.emit('close')
+    }.bind(this))
+  } else
+    this.emit('close')
+  if (err)
+    this.emit('error', err)
+  else (s != 'destroyed')
+    this.emit('end')
+}
 
-  , _cleanup: function (err) {
-      var s = this._status
-      this._status = 'ended'
-      this.readable = false
-      if (this._iterator) {
-        this._iterator.end(function () {
-          this.emit('close')
-        }.bind(this))
-      } else
-        this.emit('close')
-      if (err)
-        this.emit('error', err)
-      else (s != 'destroyed')
-        this.emit('end')
-    }
-
-  , toString: function () {
-      return 'LevelUP.ReadStream'
-    }
+ReadStream.prototype.toString = function () {
+  return 'LevelUP.ReadStream'
 }
 
 module.exports.create = function (options, db, iteratorFactory) {

--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -1,6 +1,7 @@
 /* Copyright (c) 2012 Rod Vagg <@rvagg> */
 
 var Stream       = require('stream').Stream
+  , inherits     = require('util').inherits
   , concatStream = require('concat-stream')
 
   , extend       = require('./util').extend
@@ -9,7 +10,6 @@ var Stream       = require('stream').Stream
   , defaultOptions = {}
 
 function WriteStream (options, db) {
-  this.__proto__.__proto__ = Stream.prototype
   Stream.call(this)
   this._options = extend(extend({}, defaultOptions), options)
   this._db      = db
@@ -33,115 +33,115 @@ function WriteStream (options, db) {
     db.once('ready', ready)
 }
 
-WriteStream.prototype = {
-    write: function (data) {
-      if (!this.writable)
-        return false
-      this._buffer.push(data)
-      if (this._status != 'init')
-        this._processDelayed()
-      if (this._options.maxBufferLength && this._buffer.length > this._options.maxBufferLength) {
-        this._writeBlock = true
-        return false
-      }
-      return true
-    }
+inherits(WriteStream, Stream)
 
-  , end: function() {
-      setImmediate(function () {
-        this._end = true
-        this._process()
-      }.bind(this))
-    }
+WriteStream.prototype.write = function (data) {
+  if (!this.writable)
+    return false
+  this._buffer.push(data)
+  if (this._status != 'init')
+    this._processDelayed()
+  if (this._options.maxBufferLength && this._buffer.length > this._options.maxBufferLength) {
+    this._writeBlock = true
+    return false
+  }
+  return true
+}
 
-  , destroy: function() {
+WriteStream.prototype.end = function() {
+  setImmediate(function () {
+    this._end = true
+    this._process()
+  }.bind(this))
+}
+
+WriteStream.prototype.destroy = function() {
+  this.writable = false
+  this.end()
+}
+
+WriteStream.prototype.destroySoon = function() {
+  this.end()
+}
+
+WriteStream.prototype.add = function(entry) {
+  if (!entry.props)
+    return
+  if (entry.props.Directory)
+    entry.pipe(this._db.writeStream(this._options))
+  else if (entry.props.File || entry.File || entry.type == 'File')
+    this._write(entry)
+  return true
+}
+
+WriteStream.prototype._processDelayed = function() {
+  setImmediate(this._process.bind(this))
+}
+
+WriteStream.prototype._process = function() {
+  var cb = function (err) {
+    if (!this.writable)
+      return
+    if (this._status != 'closed')
+      this._status = 'ready'
+    if (err) {
       this.writable = false
-      this.end()
+      return this.emit('error', err)
     }
+    this._process()
+  }.bind(this)
+  , buffer, entry
 
-  , destroySoon: function() {
-      this.end()
+  if (this._status != 'ready' && this.writable) {
+    if (this._buffer.length && this._status != 'closed')
+      this._processDelayed()
+    return
+  }
+
+  if (this._buffer.length && this.writable) {
+    this._status = 'writing'
+    buffer = this._buffer
+    this._buffer = []
+    if (this._buffer.length == 1) {
+      entry = this._buffer.pop()
+      if (entry.key !== undefined && entry.value !== undefined)
+        this._db.put(entry.key, entry.value, cb)
+    } else {
+      this._db.batch(buffer.map(function (d) {
+        return { type: 'put', key: d.key, value: d.value }
+      }), cb)
     }
-
-  , add: function(entry) {
-      if (!entry.props)
-        return
-      if (entry.props.Directory)
-        entry.pipe(this._db.writeStream(this._options))
-      else if (entry.props.File || entry.File || entry.type == 'File')
-        this._write(entry)
-      return true
+    if (this._writeBlock) {
+      this._writeBlock = false
+      this.emit('drain')
     }
+  }
 
-  , _processDelayed: function() {
-      setImmediate(this._process.bind(this))
+  if (this._end && this._status != 'closed') {
+    this._status = 'closed'
+    this.writable = false
+    this.emit('close')
+    return
+  }
+}
+
+WriteStream.prototype._write = function (entry) {
+  var key = entry.path || entry.props.path
+  if (!key)
+    return
+  entry.pipe(concatStream(function (err, data) {
+    if (err) {
+      this.writable = false
+      return this.emit('error', err)
     }
+    if (this._options.fstreamRoot && key.indexOf(this._options.fstreamRoot) > -1)
+      key = key.substr(this._options.fstreamRoot.length + 1)
+    this.write({ key: key, value: data })
+  }.bind(this)))
+}
 
-  , _process: function() {
-      var cb = function (err) {
-            if (!this.writable)
-              return
-            if (this._status != 'closed')
-              this._status = 'ready'
-            if (err) {
-              this.writable = false
-              return this.emit('error', err)
-            }
-            this._process()
-          }.bind(this)
-        , buffer, entry
-
-      if (this._status != 'ready' && this.writable) {
-        if (this._buffer.length && this._status != 'closed')
-          this._processDelayed()
-        return
-      }
-
-      if (this._buffer.length && this.writable) {
-        this._status = 'writing'
-        buffer = this._buffer
-        this._buffer = []
-        if (this._buffer.length == 1) {
-          entry = this._buffer.pop()
-          if (entry.key !== undefined && entry.value !== undefined)
-            this._db.put(entry.key, entry.value, cb)
-        } else {
-          this._db.batch(buffer.map(function (d) {
-            return { type: 'put', key: d.key, value: d.value }
-          }), cb)
-        }
-        if (this._writeBlock) {
-          this._writeBlock = false
-          this.emit('drain')
-        }
-      }
-
-      if (this._end && this._status != 'closed') {
-        this._status = 'closed'
-        this.writable = false
-        this.emit('close')
-        return
-      }
-    }
-
-  , _write: function (entry) {
-      var key = entry.path || entry.props.path
-      if (!key)
-        return
-      entry.pipe(concatStream(function (err, data) {
-        if (err) {
-          this.writable = false
-          return this.emit('error', err)
-        }
-        if (this._options.fstreamRoot && key.indexOf(this._options.fstreamRoot) > -1)
-          key = key.substr(this._options.fstreamRoot.length + 1)
-        this.write({ key: key, value: data })
-      }.bind(this)))
-    }
-
-  , toString: function () {
-      return 'LevelUP.WriteStream'
-    }
+WriteStream.prototype.toString = function () {
+  return 'LevelUP.WriteStream'
 }
 
 module.exports.create = function (options, db) {


### PR DESCRIPTION
I'm going to attempt some refactoring on parts of the code. This is what I'm best at. I've been a maintenance coder for many years and we all know it's important to polish the code until it shines. Not everyone might agree with my opinions though, but I thought that I'd give it a try anyway and see what you guys think. Perhaps we can all learn something in the end :)

I think we should use util.inherits( ) from node core instead of the non standard **proto**.**proto** and for two reasons. First is clarity. It's much more clear what's going on in the code when you see a call to inherits( ). The second reason is symmetry. We should create our inheritance chains the same way through all layers. We also get the _super property that can be useful to have.

Since we are not using **proto**.**proto** it means we can no longer type:

ReadStream.prototype = { }

since it would kill the prototype object that is created by the call to Object.create( ) in util.inherits( ). Some people might use this as an argument because it factors out "ReadStream.prototype" which I can agree on to some extent. But as the object literal and the methods grow larger, the more page downs and page ups you need to see what prototype object literal you are reading right now and it's not clear exactly what methods you are looking at.

This gist should show what I'm getting at: https://gist.github.com/4439706

Another argument for this is scope. We lose one level of indentation. Would be nice to hear your thoughts on this. There is probably something I haven't thought of :)

Cheers
/Magnus
