### PR TITLE
fix: incorrect scope in approximateSize func

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -320,7 +320,7 @@ LevelUP.prototype.approximateSize = function(start, end, callback) {
     throw err
   }
 
-  var cb = function(err, size) {
+  this._db.approximateSize(start, end, function(err, size) {
     if (err) {
       err = new errors.OpenError(err)
       if (callback)
@@ -328,11 +328,7 @@ LevelUP.prototype.approximateSize = function(start, end, callback) {
       this.emit('error', err)
     } else if (callback)
       callback(null, size)
-  }
-
-  cb = cb.bind(this)
-
-  this._db.approximateSize(start, end, cb)
+  }.bind(this))
 }
 
 LevelUP.prototype.readStream = function (options) {


### PR DESCRIPTION
The following code should give a helpful error about missing a name like this

```
events.js:68
        throw arguments[1]; // Unhandled 'error' event
                       ^
OpenError: #name cannot be `null` or `undefined`
```

Code

``` js
var levelup = require('levelup');
levelup('./testdb', function(err, db){
        db.approximateSize(function(err, size){
                if(err)
                        console.log(err);
                console.log(size);
        });
});
```

However we get this instead

```
/Users/sandfox/code/testme/node_modules/levelup/lib/levelup.js:323
      this.emit('error', err)
           ^
TypeError: Object #<Object> has no method 'emit'
    at LevelUP.approximateSize (/Users/sandfox/code/testme/node_modules/levelup/lib/levelup.js:323:12)
    at LevelUP.approximateSize (/Users/sandfox/code/testme/node_modules/levelup/lib/levelup.js:318:12)
    at /Users/sandfox/code/testme/test-error.js:5:5
    at LevelUP.open (/Users/sandfox/code/testme/node_modules/levelup/lib/levelup.js:86:11)
```

I've narrowed it down to scope issue and have hacked up a fix. My javascript skills aren't that great so feel free to bat down or suggest improvements. 
Also I haven't made any proper test cases apart from the above
