### PR TITLE
swap bufferstream for simple-bufferstream

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -4,7 +4,7 @@
  */
 
 var Stream       = require('stream').Stream
-  , BufferStream = require('bufferstream')
+  , bufferStream = require('simple-bufferstream')
   , inherits     = require('util').inherits
   , extend       = require('util')._extend
 
@@ -61,6 +61,7 @@ function ReadStream (options, db, iteratorFactory) {
   var ready = function () {
     if (this._status == 'ended')
       return
+
     this._iterator = iteratorFactory(this._options)
     this.emit('ready')
     this._read()
@@ -98,19 +99,16 @@ ReadStream.prototype.pipe = function (dest) {
   if (typeof dest.add == 'function' && this._options.type == 'fstream') {
     this._dataEvent = 'entry'
     this.on('entry', function (data) {
-      var entry = new BufferStream()
+      var entry = bufferStream(new Buffer(data.value))
       entry.path = data.key.toString()
       entry.type = 'File'
       entry.props = {
-        type: 'File'
+          type: 'File'
         , path: data.key.toString()
       }
-      entry.once('data', process.nextTick.bind(null, entry.end.bind(entry)))
       entry.pause()
-      if (dest.add(entry) === false) {
+      if (dest.add(entry) === false)
         this.pause()
-      }
-      entry.write(data.value)
     }.bind(this))
   }
   return Stream.prototype.pipe.apply(this, arguments)

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   , "dependencies"    : {
         "errno"           : "~0.0.3"
       , "bindings"        : "~1.0.0"
-      , "concat-stream"   : "~0.0.9"
-      , "bufferstream"    : "~0.5.1"
+      , "concat-stream"   : "~0.1.1"
+      , "simple-bufferstream" : "~0.0.2"
     }
   , "devDependencies" : {
         "buster"          : "*"


### PR DESCRIPTION
This removes bufferstream from the deps list which removes buffertools which removes an additional gyp build.

It's only needed for _fstream_ compatibility anyway.
