### PR TITLE
remove CloseError

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,18 +1,17 @@
 /* Copyright (c) 2012-2013 LevelUP contributors
  * See list at <https://github.com/rvagg/node-levelup#contributing>
- * MIT +no-false-attribs License <https://github.com/rvagg/node-levelup/blob/master/LICENSE>
+ * MIT +no-false-attribs License
+ * <https://github.com/rvagg/node-levelup/blob/master/LICENSE>
  */
 
-var errno = require('errno')
-
-  , LevelUPError = errno.custom.createError('LevelUPError')
+var createError  = require('errno').custom.createError
+  , LevelUPError = createError('LevelUPError')
 
 module.exports = {
     LevelUPError        : LevelUPError
-  , InitializationError : errno.custom.createError('InitializationError', LevelUPError)
-  , OpenError           : errno.custom.createError('OpenError', LevelUPError)
-  , ReadError           : errno.custom.createError('ReadError', LevelUPError)
-  , WriteError          : errno.custom.createError('WriteError', LevelUPError)
-  , NotFoundError       : errno.custom.createError('NotFoundError', LevelUPError)
-  , CloseError          : errno.custom.createError('CloseError', LevelUPError)
+  , InitializationError : createError('InitializationError', LevelUPError)
+  , OpenError           : createError('OpenError', LevelUPError)
+  , ReadError           : createError('ReadError', LevelUPError)
+  , WriteError          : createError('WriteError', LevelUPError)
+  , NotFoundError       : createError('NotFoundError', LevelUPError)
 }

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -123,8 +123,6 @@ var bridge       = require('bindings')('levelup.node')
       }
 
       LevelUP.prototype.close = function (callback) {
-        var err
-
         if (isOpen()) {
           status = 'closing'
           this._db.close(function () {
@@ -135,21 +133,14 @@ var bridge       = require('bindings')('levelup.node')
           }.bind(this))
           this.emit('closing')
           this._db = null
-        } else if (status == 'closed') {
-          if (callback)
-            callback()
-        } else if (status == 'closing') {
-          if (callback)
-            this.once('closed', callback)
+        } else if (status == 'closed' && callback) {
+          callback()
+        } else if (status == 'closing' && callback) {
+          this.once('closed', callback)
         } else if (status == 'opening') {
           this.once('open', function () {
             this.close(callback)
           })
-        } else {
-          err = new errors.CloseError('Cannot close unopened database')
-          if (callback)
-            return callback(err)
-          this.emit('error', err)
         }
       }
 


### PR DESCRIPTION
The final else case in LevelUP#close() corresponds to the status
'new', which is the state the database has after the constructor
has been called. Since we always call LevelUP#open() before
returning the database object, it's impossible for the user to
call close() while the database is in the state 'new'. Therefore
the CloseError() can never happen.
