### PR TITLE
emit error events instead of throwing where possible

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -52,9 +52,12 @@ var bridge       = require('bindings')('levelup.node')
         , error
         , levelup
 
-        , isOpen   = function () { return status == 'open' }
-        , isClosed = function () { return (/^clos/).test(status) }
-        , inLimbo  = function () { return !isOpen() && !isClosed() }
+        , isOpen        = function () { return status == 'open' }
+        , isClosed      = function () { return (/^clos/).test(status) }
+        , inLimbo       = function () { return !isOpen() && !isClosed() }
+        , dispatchError = function (error, callback) {
+            return callback ? callback(error) : levelup.emit('error', error)
+          }
 
       if (typeof options == 'function') {
         callback = options
@@ -64,10 +67,8 @@ var bridge       = require('bindings')('levelup.node')
       if (typeof location != 'string') {
         error = new errors.InitializationError(
             'Must provide a location for the database')
-
         if (callback)
           return callback(error)
-
         throw error
       }
 
@@ -104,11 +105,9 @@ var bridge       = require('bindings')('levelup.node')
           db.open(this.location, this._options, function (err) {
             if (err) {
               err = new errors.OpenError(err)
-              if (callback)
-                return callback(err)
-              this.emit('error', err)
+              return dispatchError(err, callback)
             } else {
-              this._db     = db
+              this._db = db
               status = 'open'
               if (callback)
                 callback(null, this)
@@ -175,19 +174,14 @@ var bridge       = require('bindings')('levelup.node')
             if (err) {
               err = new errors.NotFoundError(
                   'Key not found in database [' + key_ + ']')
-
-              if (callback)
-                return callback(err)
-              throw err
+              return dispatchError(err, callback)
             }
             if (callback)
               callback(null, toEncoding[valueEnc](value), key_)
           })
         } else {
           err = new errors.ReadError('Database is not open')
-          if (callback)
-            return callback(err)
-          throw err
+          return dispatchError(err, callback)
         }
       }
 
@@ -214,9 +208,7 @@ var bridge       = require('bindings')('levelup.node')
           this._db.put(key, value, options, function (err) {
             if (err) {
               err = new errors.WriteError(err)
-              if (callback)
-                return callback(err)
-              this.emit('error', err)
+              return dispatchError(err, callback)
             } else {
               this.emit('put', key_, value_)
               if (callback)
@@ -225,9 +217,7 @@ var bridge       = require('bindings')('levelup.node')
           }.bind(this))
         } else {
           err = new errors.WriteError('Database is not open')
-          if (callback)
-            return callback(err)
-          throw err
+          return dispatchError(err, callback)
         }
       }
 
@@ -252,9 +242,7 @@ var bridge       = require('bindings')('levelup.node')
           this._db.del(key, options, function (err) {
             if (err) {
               err = new errors.WriteError(err)
-              if (callback)
-                return callback(err)
-              this.emit('error', err)
+              return dispatchError(err, callback)
             } else {
               this.emit('del', key_)
               if (callback)
@@ -263,9 +251,7 @@ var bridge       = require('bindings')('levelup.node')
           }.bind(this))
         } else {
           err = new errors.WriteError('Database is not open')
-          if (callback)
-            return callback(err)
-          throw err
+          return dispatchError(err, callback)
         }
       }
 
@@ -287,9 +273,7 @@ var bridge       = require('bindings')('levelup.node')
 
         if (isClosed()) {
           err = new errors.WriteError('Database is not open')
-          if (callback)
-            return callback(err)
-          throw err
+          return dispatchError(err, callback)
         }
 
         options       = getOptions(options_, this._options)
@@ -320,9 +304,7 @@ var bridge       = require('bindings')('levelup.node')
         this._db.batch(arr, options, function (err) {
           if (err) {
             err = new errors.WriteError(err)
-            if (callback)
-              return callback(err)
-            this.emit('error', err)
+            return dispatchError(err, callback)
           } else {
             this.emit('batch', arr_)
             if (callback)
@@ -342,17 +324,13 @@ var bridge       = require('bindings')('levelup.node')
 
         if (isClosed()) {
           err = new errors.WriteError('Database is not open')
-          if (callback)
-            return callback(err)
-          throw err
+          return dispatchError(err, callback)
         }
 
         this._db.approximateSize(start, end, function(err, size) {
           if (err) {
             err = new errors.OpenError(err)
-            if (callback)
-              return callback(err)
-            this.emit('error', err)
+            return dispatchError(err, callback)
           } else if (callback)
             callback(null, size)
         }.bind(this))


### PR DESCRIPTION
refactored into dispatchError(err, callback), which
calls the callback if it's set, otherwise emits the error
on the db object

This closes #48 
