### PR TITLE
inLimbo -> isOpening

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -54,7 +54,7 @@ var bridge       = require('bindings')('levelup.node')
 
         , isOpen        = function () { return status == 'open' }
         , isClosed      = function () { return (/^clos/).test(status) }
-        , inLimbo       = function () { return !isOpen() && !isClosed() }
+        , isOpening     = function () { return status == 'opening' }
         , dispatchError = function (error, callback) {
             return callback ? callback(error) : levelup.emit('error', error)
           }
@@ -94,7 +94,7 @@ var bridge       = require('bindings')('levelup.node')
           return this
         }
 
-        if (status == 'opening')
+        if (isOpening())
           return callback && this.once('open', callback.bind(null, null, this))
 
         status = 'opening'
@@ -136,7 +136,7 @@ var bridge       = require('bindings')('levelup.node')
           callback()
         } else if (status == 'closing' && callback) {
           this.once('closed', callback)
-        } else if (status == 'opening') {
+        } else if (isOpening()) {
           this.once('open', function () {
             this.close(callback)
           })
@@ -155,7 +155,7 @@ var bridge       = require('bindings')('levelup.node')
           , valueEnc
           , err
 
-        if (inLimbo()) {
+        if (isOpening()) {
           return this.once('ready', function () {
             this.get(key_, options_, callback_)
           })
@@ -192,7 +192,7 @@ var bridge       = require('bindings')('levelup.node')
           , key
           , value
 
-        if (inLimbo()) {
+        if (isOpening()) {
           return this.once('ready', function () {
             this.put(key_, value_, options_, callback_)
           })
@@ -227,7 +227,7 @@ var bridge       = require('bindings')('levelup.node')
           , err
           , key
 
-        if (inLimbo()) {
+        if (isOpening()) {
           return this.once('ready', function () {
             this.del(key_, options_, callback_)
           })
@@ -263,7 +263,7 @@ var bridge       = require('bindings')('levelup.node')
           , err
           , arr
 
-        if (inLimbo()) {
+        if (isOpening()) {
           return this.once('ready', function () {
             this.batch(arr_, options_, callback_)
           })
@@ -316,7 +316,7 @@ var bridge       = require('bindings')('levelup.node')
       LevelUP.prototype.approximateSize = function(start, end, callback) {
         var err
 
-        if (inLimbo()) {
+        if (isOpening()) {
           return this.once('ready', function () {
             this.approximateSize(start, end, callback)
           })


### PR DESCRIPTION
inLimbo == !isOpen && !isClosed, which is the same as the
state 'new' or 'opening', but for the same reasons of
removing the CloseError, we never return the LevelUP object
in the state 'new', therefore inLimbo really means isOpening
