### PR TITLE
use !isOpen() and bail out early in all methods

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -53,7 +53,6 @@ var bridge       = require('bindings')('levelup.node')
         , levelup
 
         , isOpen        = function () { return status == 'open' }
-        , isClosed      = function () { return (/^clos/).test(status) }
         , isOpening     = function () { return status == 'opening' }
         , dispatchError = function (error, callback) {
             return callback ? callback(error) : levelup.emit('error', error)
@@ -145,7 +144,7 @@ var bridge       = require('bindings')('levelup.node')
 
       LevelUP.prototype.isOpen = function () { return isOpen() }
 
-      LevelUP.prototype.isClosed = function () { return isClosed() }
+      LevelUP.prototype.isClosed = function () { return (/^clos/).test(status) }
 
       LevelUP.prototype.get = function (key_, options_, callback_) {
         var callback
@@ -163,26 +162,26 @@ var bridge       = require('bindings')('levelup.node')
 
         callback = getCallback(options_, callback_)
 
-        if (isOpen()) {
-          options  = getOptions(options_, this._options)
-          keyEnc   = options.keyEncoding   || options.encoding
-          valueEnc = options.valueEncoding || options.encoding
-          key      = toSlice[keyEnc](key_)
-          options.asBuffer = valueEnc != 'utf8' && valueEnc != 'json'
-
-          this._db.get(key, options, function (err, value) {
-            if (err) {
-              err = new errors.NotFoundError(
-                  'Key not found in database [' + key_ + ']')
-              return dispatchError(err, callback)
-            }
-            if (callback)
-              callback(null, toEncoding[valueEnc](value), key_)
-          })
-        } else {
+        if (!isOpen()) {
           err = new errors.ReadError('Database is not open')
           return dispatchError(err, callback)
         }
+
+        options  = getOptions(options_, this._options)
+        keyEnc   = options.keyEncoding   || options.encoding
+        valueEnc = options.valueEncoding || options.encoding
+        key      = toSlice[keyEnc](key_)
+        options.asBuffer = valueEnc != 'utf8' && valueEnc != 'json'
+
+        this._db.get(key, options, function (err, value) {
+          if (err) {
+            err = new errors.NotFoundError(
+                'Key not found in database [' + key_ + ']')
+            return dispatchError(err, callback)
+          }
+          if (callback)
+            callback(null, toEncoding[valueEnc](value), key_)
+        })
       }
 
       LevelUP.prototype.put = function (key_, value_, options_, callback_) {
@@ -200,25 +199,25 @@ var bridge       = require('bindings')('levelup.node')
 
         callback = getCallback(options_, callback_)
 
-        if (isOpen()) {
-          options = getOptions(options_, this._options)
-          key     = toSlice[options.keyEncoding   || options.encoding](key_)
-          value   = toSlice[options.valueEncoding || options.encoding](value_)
-
-          this._db.put(key, value, options, function (err) {
-            if (err) {
-              err = new errors.WriteError(err)
-              return dispatchError(err, callback)
-            } else {
-              this.emit('put', key_, value_)
-              if (callback)
-                callback(null, key, value)
-            }
-          }.bind(this))
-        } else {
+        if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
+
+        options = getOptions(options_, this._options)
+        key     = toSlice[options.keyEncoding   || options.encoding](key_)
+        value   = toSlice[options.valueEncoding || options.encoding](value_)
+
+        this._db.put(key, value, options, function (err) {
+          if (err) {
+            err = new errors.WriteError(err)
+            return dispatchError(err, callback)
+          } else {
+            this.emit('put', key_, value_)
+            if (callback)
+              callback(null, key, value)
+          }
+        }.bind(this))
       }
 
       LevelUP.prototype.del = function (key_, options_, callback_) {
@@ -235,24 +234,24 @@ var bridge       = require('bindings')('levelup.node')
 
         callback = getCallback(options_, callback_)
 
-        if (isOpen()) {
-          options = getOptions(options_, this._options)
-          key     = toSlice[options.keyEncoding || options.encoding](key_)
-
-          this._db.del(key, options, function (err) {
-            if (err) {
-              err = new errors.WriteError(err)
-              return dispatchError(err, callback)
-            } else {
-              this.emit('del', key_)
-              if (callback)
-                callback(null, key)
-            }
-          }.bind(this))
-        } else {
+        if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
+
+        options = getOptions(options_, this._options)
+        key     = toSlice[options.keyEncoding || options.encoding](key_)
+
+        this._db.del(key, options, function (err) {
+          if (err) {
+            err = new errors.WriteError(err)
+            return dispatchError(err, callback)
+          } else {
+            this.emit('del', key_)
+            if (callback)
+              callback(null, key)
+          }
+        }.bind(this))
       }
 
       LevelUP.prototype.batch = function (arr_, options_, callback_) {
@@ -271,7 +270,7 @@ var bridge       = require('bindings')('levelup.node')
 
         callback = getCallback(options_, callback_)
 
-        if (isClosed()) {
+        if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
@@ -322,7 +321,7 @@ var bridge       = require('bindings')('levelup.node')
           })
         }
 
-        if (isClosed()) {
+        if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
@@ -353,19 +352,19 @@ var bridge       = require('bindings')('levelup.node')
 
       LevelUP.prototype.keyStream = function (options) {
         return this.readStream(
-          extend(
-              options ? extend({}, options) : {}
-            , { keys: true, values: false }
-          )
+            extend(
+                options ? extend({}, options) : {}
+              , { keys: true, values: false }
+            )
         )
       }
 
       LevelUP.prototype.valueStream = function (options) {
         return this.readStream(
-          extend(
-              options ? extend({}, options) : {}
-            , { keys: false, values: true }
-          )
+            extend(
+                options ? extend({}, options) : {}
+              , { keys: false, values: true }
+            )
         )
       }
 


### PR DESCRIPTION
There were different ways of checking the state of the db before actually doing something:

Check if open and do something, else bail:

``` js
if (isOpen()) {
  // Do stuff
} else {
  // Bail
}
```

Check if closed and bail, else do something:

``` js
if (isClosed()) {
  // Bail
}
// Do stuff
```

I chose the second one for all methods, but replaced `isClosed()` with `!isOpen()`. The reasons for this are:
- Consistency
- Get rid of a level of indentation
- No longer internally dependent of the `isClosed()` method ->
  Easier to remove if we so choose.
