### PR TITLE
refactor options for db

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -25,17 +25,8 @@ var leveldown    = require('leveldown')
       , compression     : true
     }
 
-  , getOptions = function (options, globalOptions) {
-      return typeof options == 'string' // just an encoding
-        ? options = extend(
-              {}
-            , encodingOpts[options] || encodingOpts[defaultOptions.encoding]
-          )
-        : extend(extend({}, globalOptions), options)
-    }
-
-  , getCallback = function (options_, callback_) {
-      return typeof options_ == 'function' ? options_ : callback_
+  , getCallback = function (options, callback) {
+      return typeof options == 'function' ? options : callback
     }
 
   , createLevelUP = function (location, options, callback) {
@@ -54,10 +45,22 @@ var leveldown    = require('leveldown')
 
         , isOpen        = function () { return status == 'open' }
         , isOpening     = function () { return status == 'opening' }
+
         , keyEncoding   = function (o) { return o.keyEncoding || o.encoding }
         , valueEncoding = function (o) { return o.valueEncoding || o.encoding }
+
         , dispatchError = function (error, callback) {
             return callback ? callback(error) : levelup.emit('error', error)
+          }
+
+        , getOptions = function (options) {
+            return typeof options == 'string' // just an encoding
+              ? extend(
+                    {}
+                  , encodingOpts[options] ||
+                    encodingOpts[defaultOptions.encoding]
+                )
+            : extend(extend({}, levelup._options), options)
           }
 
       if (typeof options == 'function') {
@@ -77,7 +80,7 @@ var leveldown    = require('leveldown')
         EventEmitter.call(this)
         this.setMaxListeners(Infinity)
 
-        this._options  = extend(extend({}, defaultOptions), options)
+        this._options = extend(extend({}, defaultOptions), options)
         Object.defineProperty(this, 'location', {
             value: location
           , configurable: false
@@ -148,27 +151,26 @@ var leveldown    = require('leveldown')
 
       LevelUP.prototype.isClosed = function () { return (/^clos/).test(status) }
 
-      LevelUP.prototype.get = function (key_, options_, callback_) {
+      LevelUP.prototype.get = function (key_, options, callback_) {
         var callback
-          , options
           , key
           , valueEnc
           , err
 
         if (isOpening()) {
           return this.once('ready', function () {
-            this.get(key_, options_, callback_)
+            this.get(key_, options, callback_)
           })
         }
 
-        callback = getCallback(options_, callback_)
+        callback = getCallback(options, callback_)
 
         if (!isOpen()) {
           err = new errors.ReadError('Database is not open')
           return dispatchError(err, callback)
         }
 
-        options  = getOptions(options_, this._options)
+        options  = getOptions(options)
         key      = toSlice[keyEncoding(options)](key_)
         valueEnc = valueEncoding(options)
         options.asBuffer = valueEnc != 'utf8' && valueEnc != 'json'
@@ -184,27 +186,26 @@ var leveldown    = require('leveldown')
         })
       }
 
-      LevelUP.prototype.put = function (key_, value_, options_, callback_) {
+      LevelUP.prototype.put = function (key_, value_, options, callback_) {
         var callback
-          , options
           , err
           , key
           , value
 
         if (isOpening()) {
           return this.once('ready', function () {
-            this.put(key_, value_, options_, callback_)
+            this.put(key_, value_, options, callback_)
           })
         }
 
-        callback = getCallback(options_, callback_)
+        callback = getCallback(options, callback_)
 
         if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
 
-        options = getOptions(options_, this._options)
+        options = getOptions(options)
         key     = toSlice[keyEncoding(options)](key_)
         value   = toSlice[valueEncoding(options)](value_)
 
@@ -220,26 +221,25 @@ var leveldown    = require('leveldown')
         }.bind(this))
       }
 
-      LevelUP.prototype.del = function (key_, options_, callback_) {
+      LevelUP.prototype.del = function (key_, options, callback_) {
         var callback
-          , options
           , err
           , key
 
         if (isOpening()) {
           return this.once('ready', function () {
-            this.del(key_, options_, callback_)
+            this.del(key_, options, callback_)
           })
         }
 
-        callback = getCallback(options_, callback_)
+        callback = getCallback(options, callback_)
 
         if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
 
-        options = getOptions(options_, this._options)
+        options = getOptions(options)
         key     = toSlice[keyEncoding(options)](key_)
 
         this._db.del(key, options, function (err) {
@@ -254,9 +254,8 @@ var leveldown    = require('leveldown')
         }.bind(this))
       }
 
-      LevelUP.prototype.batch = function (arr_, options_, callback_) {
+      LevelUP.prototype.batch = function (arr_, options, callback_) {
         var callback
-          , options
           , keyEnc
           , valueEnc
           , err
@@ -264,18 +263,18 @@ var leveldown    = require('leveldown')
 
         if (isOpening()) {
           return this.once('ready', function () {
-            this.batch(arr_, options_, callback_)
+            this.batch(arr_, options, callback_)
           })
         }
 
-        callback = getCallback(options_, callback_)
+        callback = getCallback(options, callback_)
 
         if (!isOpen()) {
           err = new errors.WriteError('Database is not open')
           return dispatchError(err, callback)
         }
 
-        options  = getOptions(options_, this._options)
+        options  = getOptions(options)
         keyEnc   = keyEncoding(options)
         valueEnc = valueEncoding(options)
 


### PR DESCRIPTION
move getOptions() into closure -> we can remove the this._options parameter

remove options variable from methods, use parameter instead
this is safe since we always create a new object and extend it
