### PR TITLE
don't throw if readStream.destroy called more than once

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -76,8 +76,10 @@ function ReadStream (options, db, iteratorFactory) {
 inherits(ReadStream, Stream)
 
 ReadStream.prototype.destroy = function () {
-  this._status = 'destroyed'
-  this._cleanup()
+  if (this._status != 'ended') {
+    this._status = 'destroyed'
+    this._cleanup()
+  }
 }
 
 ReadStream.prototype.pause = function () {


### PR DESCRIPTION
It's too easy to accidentally call destroy on a readStream, and it's unforgiving. Had some greif when using dominictarr's map-reduce which assumes that it's safe to call.
