### PR TITLE
remove .bind()... sadly, for efficiency's sake

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -96,44 +96,46 @@ var leveldown    = require('leveldown')
         }
 
         if (isOpening())
-          return callback && this.once('open', callback.bind(null, null, this))
+          return callback && levelup.once(
+              'open'
+            , callback.bind(null, null, this)
+          )
 
         status = 'opening'
 
         var execute = function () {
-          var db = leveldown(this.location)
+              var db = leveldown(levelup.location)
 
-          db.open(this._options, function (err) {
-            if (err) {
-              err = new errors.OpenError(err)
-              return dispatchError(err, callback)
-            } else {
-              this._db = db
-              status = 'open'
-              if (callback)
-                callback(null, this)
-              this.emit('open')
-              this.emit('ready')
+              db.open(levelup._options, function (err) {
+                if (err) {
+                  err = new errors.OpenError(err)
+                  return dispatchError(err, callback)
+                } else {
+                  levelup._db = db
+                  status = 'open'
+                  if (callback)
+                    callback(null, levelup)
+                  levelup.emit('open')
+                  levelup.emit('ready')
+                }
+              })
             }
-          }.bind(this))
-        }.bind(this)
-
-        var deferred = {}
+          , deferred = {}
 
         ;['get', 'put', 'batch', 'del', 'approximateSize']
           .forEach(function (name) {
             deferred[name] = function () {
               var args = Array.prototype.slice.call(arguments)
-              this.once('ready', function () {
-                this._db[name].apply(this._db, args)
+              levelup.once('ready', function () {
+                levelup._db[name].apply(levelup._db, args)
               })
-            }.bind(this)
-          }.bind(this))
+            }
+          })
 
         this._db = deferred
 
         execute()
-        this.emit('opening')
+        levelup.emit('opening')
       }
 
       LevelUP.prototype.close = function (callback) {
@@ -141,19 +143,19 @@ var leveldown    = require('leveldown')
           status = 'closing'
           this._db.close(function () {
             status = 'closed'
-            this.emit('closed')
+            levelup.emit('closed')
             if (callback)
               callback.apply(null, arguments)
-          }.bind(this))
-          this.emit('closing')
+          })
+          levelup.emit('closing')
           this._db = null
         } else if (status == 'closed' && callback) {
           callback()
         } else if (status == 'closing' && callback) {
-          this.once('closed', callback)
+          levelup.once('closed', callback)
         } else if (isOpening()) {
-          this.once('open', function () {
-            this.close(callback)
+          levelup.once('open', function () {
+            levelup.close(callback)
           })
         }
       }
@@ -211,11 +213,11 @@ var leveldown    = require('leveldown')
             err = new errors.WriteError(err)
             return dispatchError(err, callback)
           } else {
-            this.emit('put', key_, value_)
+            levelup.emit('put', key_, value_)
             if (callback)
               callback()
           }
-        }.bind(this))
+        })
       }
 
       LevelUP.prototype.del = function (key_, options, callback) {
@@ -237,11 +239,11 @@ var leveldown    = require('leveldown')
             err = new errors.WriteError(err)
             return dispatchError(err, callback)
           } else {
-            this.emit('del', key_)
+            levelup.emit('del', key_)
             if (callback)
               callback()
           }
-        }.bind(this))
+        })
       }
 
       LevelUP.prototype.batch = function (arr_, options, callback) {
@@ -287,11 +289,11 @@ var leveldown    = require('leveldown')
             err = new errors.WriteError(err)
             return dispatchError(err, callback)
           } else {
-            this.emit('batch', arr_)
+            levelup.emit('batch', arr_)
             if (callback)
               callback()
           }
-        }.bind(this))
+        })
       }
 
       LevelUP.prototype.approximateSize = function(start, end, callback) {
@@ -308,7 +310,7 @@ var leveldown    = require('leveldown')
             return dispatchError(err, callback)
           } else if (callback)
             callback(null, size)
-        }.bind(this))
+        })
       }
 
       LevelUP.prototype.readStream =
@@ -318,8 +320,8 @@ var leveldown    = require('leveldown')
             options
           , this
           , function (options) {
-              return this._db.iterator(options)
-            }.bind(this)
+              return levelup._db.iterator(options)
+            }
         )
       }
 


### PR DESCRIPTION
ref #87, purely for the performance gain demonstrated by the benchmarks.

```
LevelUP           put(int, string) x 10 x 920 ops/sec ±0.63% (41 runs sampled)
LevelUP (release) put(int, string) x 10 x 916 ops/sec ±0.75% (32 runs sampled)

LevelUP           put(int, string) x 1000 x 186 ops/sec ±2.68% (70 runs sampled)
LevelUP (release) put(int, string) x 1000 x 115 ops/sec ±2.00% (80 runs sampled)

LevelUP           put(int, string) x 100,000 x 1.38 ops/sec ±22.51% (12 runs sampled)
LevelUP (release) put(int, string) x 100,000 x 0.94 ops/sec ±2.59% (9 runs sampled)

LevelUP           get(int):string x 10 x 927 ops/sec ±0.65% (21 runs sampled)
LevelUP (release) get(int):string x 10 x 911 ops/sec ±3.00% (18 runs sampled)

LevelUP           get(int):string x 1000 x 169 ops/sec ±2.58% (76 runs sampled)
LevelUP (release) get(int):string x 1000 x 160 ops/sec ±2.28% (75 runs sampled)

LevelUP           batch(int, string) x 1000 x 400 ops/sec ±2.41% (85 runs sampled)
LevelUP (release) batch(int, string) x 1000 x 397 ops/sec ±2.54% (85 runs sampled)

LevelUP           batch(int, string) x 100,000 x 2.21 ops/sec ±78.31% (8 runs sampled)
LevelUP (release) batch(int, string) x 100,000 x 3.42 ops/sec ±2.29% (8 runs sampled)
```
