### PR TITLE
Make LevelDOWN an optional dependency

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -4,8 +4,7 @@
  * <https://github.com/rvagg/node-levelup/blob/master/LICENSE>
  */
 
-var leveldown    = require('leveldown')
-  , EventEmitter = require('events').EventEmitter
+var EventEmitter = require('events').EventEmitter
   , inherits     = require('util').inherits
   , extend       = require('xtend')
   , prr          = require('prr')
@@ -25,7 +24,6 @@ var leveldown    = require('leveldown')
       , keyEncoding     : 'utf8'
       , valueEncoding   : null
       , compression     : true
-      , db              : leveldown
     }
 
   , createLevelUP = function (location, options, callback) {
@@ -83,6 +81,16 @@ var leveldown    = require('leveldown')
         this.setMaxListeners(Infinity)
 
         this._options = extend(defaultOptions, options)
+
+        if (!this._options.db) {
+          try {
+            this._options.db = require('leveldown')
+          } catch (e) {
+            throw new new errors.InitializationError(
+              'Must provide `db` option or install LevelDOWN in your Node modules path')
+          }
+        }
+
         // set this.location as enumerable but not configurable or writable
         prr(this, 'location', location, 'e')
       }
@@ -357,11 +365,11 @@ var leveldown    = require('leveldown')
     }
 
   , destroy = function (location, callback) {
-      leveldown.destroy(location, callback || function () {})
+      require('leveldown').destroy(location, callback || function () {})
     }
 
   , repair = function (location, callback) {
-      leveldown.repair(location, callback || function () {})
+      require('leveldown').repair(location, callback || function () {})
     }
 
 module.exports         = createLevelUP

--- a/package.json
+++ b/package.json
@@ -24,15 +24,18 @@
   , "version"         : "0.7.0"
   , "main"            : "lib/levelup.js"
   , "dependencies"    : {
-        "leveldown"           : "~0.2.1"
-      , "errno"               : "~0.0.3"
+        "errno"               : "~0.0.3"
       , "concat-stream"       : "~0.1.1"
       , "simple-bufferstream" : "~0.0.2"
       , "xtend"               : "~2.0.3"
       , "prr"                 : "~0.0.0"
     }
+  , "peerDependencies" : {
+        "leveldown"       : "~0.2.1"
+    }
   , "devDependencies" : {
-        "bustermove"      : "*"
+        "leveldown"       : "~0.2.1"
+      , "bustermove"      : "*"
       , "tap"             : "*"
       , "referee"         : "*"
       , "rimraf"          : "*"


### PR DESCRIPTION
Consider this a discussion pull request.

We now have a `'db'` option on init that can swap out LevelDOWN with a suitable replacement (e.g. [MemDOWN](https://github.com/rvagg/node-memdown) or other via [Abstract LevelDOWN](https://github.com/rvagg/node-abstract-leveldown)). We'll hopefully one day have pure JS implementation(s) of LevelDB available to swap in.

So, it would be nice to not have to pull in a compiled dependency if you weren't going to need it.

This PR makes it an optional dependency but pins the version with a `'peerDependency'`. It would just add complication to install instructions because we'd have to instruct people to `npm install levelup leveldown` but hopefully the thrown `Error` would help with that.

Thoughts?
