### PR TITLE
leveldown@0.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
       , "bops"                : "~0.0.6"
     }
   , "devDependencies" : {
-        "leveldown"       : "~0.5.0"
+        "leveldown"       : "~0.6.2"
       , "bustermove"      : "*"
       , "tap"             : "*"
       , "referee"         : "*"


### PR DESCRIPTION
I have to admit that I don't know what's going on here, I just don't remember why the current LevelUP isn't synchronized to the current LevelDOWN. Level is doing ~0.6.0 but we have ~0.5.0 here...

Probably worth a bump and a release; unless someone wants to get something else in for a 0.12.0?
