### PR TITLE
Explicitly return `null` errors in callbacks where there is no error

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -380,7 +380,7 @@ var EventEmitter   = require('events').EventEmitter
           } else {
             levelup.emit('batch', arr)
             if (callback)
-              callback()
+              callback(null)
           }
         })
       }


### PR DESCRIPTION
I find returning a `null` error instead of `undefined` is a more common practice in node-land. This is handy for checking that you did indeed get something and it wasn't an error, and a couple of other 'sanity check' reasons.

It also makes wrapping callbacks easier when they all behave equivalently (right now `.get` already returns an explicit `null` error)

Obviously this is more of a flavor & consistency issue rather than a bug, but it would make the library slightly easier to use with existing node tooling. Feedback welcome, please!

e.g.

``` javascript
  function wrapCb(cb) {
    if (!cb) return

    return function () {
      var args = [].slice.call(arguments)

      // The following line is not normally needed, and
      //  would no longer be needed after this patch.
      if (args.length == 0) args.push(null)

      args.push(my_awesome_extra_return_argument)
      return cb.apply(null, args)
    }
  }
```

All tests still pass after the patch.
