### PR TITLE
Custom encodings cleanup

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -14,8 +14,6 @@ var EventEmitter   = require('events').EventEmitter
   , writeStream    = require('./write-stream')
   , util           = require('./util')
 
-  , toEncoding     = util.toEncoding
-  , toSlice        = util.toSlice
   , getOptions     = util.getOptions
   , defaultOptions = util.defaultOptions
   , getLevelDOWN   = util.getLevelDOWN
@@ -87,6 +85,9 @@ var EventEmitter   = require('events').EventEmitter
 
       LevelUP.prototype.open = function (callback) {
         var self = this
+          , dbFactory
+          , db
+
         if (isOpen()) {
           if (callback) {
             process.nextTick(function () { callback(null, self) })
@@ -106,8 +107,8 @@ var EventEmitter   = require('events').EventEmitter
         status = 'opening'
         self.db = deferred
 
-        var dbFactory = levelup.options.db || getLevelDOWN()
-          , db        = dbFactory(levelup.location)
+        dbFactory = levelup.options.db || getLevelDOWN()
+        db        = dbFactory(levelup.location)
 
         db.open(levelup.options, function (err) {
           if (err) {
@@ -152,7 +153,6 @@ var EventEmitter   = require('events').EventEmitter
 
       LevelUP.prototype.get = function (key_, options, callback) {
         var key
-          , valueEnc
           , err
 
         callback = getCallback(options, callback)
@@ -168,7 +168,7 @@ var EventEmitter   = require('events').EventEmitter
         }
 
         options = util.getOptions(levelup, options)
-        var key = util.encodeKey(key_, options)
+        key = util.encodeKey(key_, options)
 
         options.asBuffer = util.isValueAsBuffer(options)
 
@@ -265,8 +265,9 @@ var EventEmitter   = require('events').EventEmitter
 
       Batch.prototype.put = function (key_, value_, options) {
         options = getOptions(levelup, options)
-        var key     = util.encodeKey(key_, options)
-        var value   = util.encodeValue(value_, options)
+
+        var key   = util.encodeKey(key_, options)
+          , value = util.encodeValue(value_, options)
 
         try {
           this.batch.put(key, value)
@@ -322,6 +323,7 @@ var EventEmitter   = require('events').EventEmitter
         var keyEnc
           , valueEnc
           , err
+          , arr
 
         if (!arguments.length)
           return new Batch(this.db)
@@ -342,7 +344,7 @@ var EventEmitter   = require('events').EventEmitter
         keyEnc   = options.keyEncoding
         valueEnc = options.valueEncoding
 
-        var arr = arr_.map(function (e) {
+        arr = arr_.map(function (e) {
           if (e.type === undefined || e.key === undefined) {
             return {}
           }
@@ -359,8 +361,8 @@ var EventEmitter   = require('events').EventEmitter
           if (kEnc != 'utf8' && kEnc != 'binary'
               || vEnc != 'utf8' && vEnc != 'binary') {
             o = {
-              type: e.type,
-              key: util.encodeKey(e.key, options, e)
+                type: e.type
+              , key: util.encodeKey(e.key, options, e)
             }
 
             if (e.value !== undefined)
@@ -387,7 +389,8 @@ var EventEmitter   = require('events').EventEmitter
       // DEPRECATED: prefer accessing LevelDOWN for this: db.db.approximateSize()
       LevelUP.prototype.approximateSize = function (start_, end_, callback) {
         var err
-
+          , start
+          , end
 
         if (start_ === null || start_ === undefined
               || end_ === null || end_ === undefined
@@ -396,8 +399,8 @@ var EventEmitter   = require('events').EventEmitter
           return dispatchError(err, callback)
         }
 
-        var start = util.encodeKey(start_, options)
-        var end   = util.encodeKey(end_, options)
+        start = util.encodeKey(start_, options)
+        end   = util.encodeKey(end_, options)
 
         if (!isOpening() && !isOpen()) {
           err = new errors.WriteError('Database is not open')

--- a/lib/util.js
+++ b/lib/util.js
@@ -31,61 +31,41 @@ var extend = require('xtend')
 
   , leveldown
 
-  , encoders = (function () {
-      var slicers = {}
-        , isBuffer = function (data) {
-            return data === undefined || data === null || bops.is(data)
-          }
-      slicers.json = JSON.stringify
-      slicers.utf8 = function (data) {
-        return isBuffer(data) ? data : String(data)
-      }
-      encodingNames.forEach(function (enc) {
-        if (slicers[enc]) return
-        slicers[enc] = function (data) {
-          return isBuffer(data) ? data : bops.from(data, enc)
-        }
-      })
-      return slicers
-    }())
-
-  , decoders = (function () {
-      var encoders = {}
-      encoders.json = function (str) { return JSON.parse(str) }
-      encoders.utf8 = function (str) { return str }
-      encoders.binary = function (buffer) { return buffer }
-      encodingNames.forEach(function (enc) {
-        if (encoders[enc]) return
-        encoders[enc] = function (buffer) { return bops.to(buffer, enc) }
-      })
-      return encoders
-    }())
-
   , isBinary = function (data) {
-      return data === undefined || data === null || Buffer.isBuffer(data)
+      return data === undefined || data === null || bops.is(data)
     }
 
   , encodings = (function () {
-      var _encodings = {}
+      var encodings = {}
+      encodings.utf8 = encodings['utf-8'] = {
+          encode : function (data) {
+            return isBinary(data) ? data : String(data)
+          }
+        , decode : function (data) { return data }
+        , buffer : false
+        , type   : 'utf8'
+      }
+      encodings.json = {
+          encode : JSON.stringify
+        , decode : JSON.parse
+        , buffer : false
+        , type   : 'json'
+      }
       encodingNames.forEach(function (type) {
-        _encodings[type] = {
-          encode: encoders[type],
-          decode: decoders[type],
-          buffer: true,
-          type: type //useful for debugging purposes
+        if (encodings[type])
+          return
+        encodings[type] = {
+            encode : function (data) {
+              return isBinary(data) ? data : bops.from(data, type)
+            }
+          , decode : function (buffer) {
+              return bops.from(buffer, type)
+            }
+          , buffer : true
+          , type   : type // useful for debugging purposes
         }
       })
-      _encodings.utf8 = _encodings['utf-8'] = {
-        encode: function (data) {
-          return isBinary(data) ? data : String(data)
-        },
-        decode: function (data) { return data },
-        buffer: false
-      }
-      _encodings.json = {
-        encode: JSON.stringify, decode: JSON.parse, buffer: false, type: 'json'
-      }
-      return _encodings
+      return encodings
     })()
 
   , copy = function (srcdb, dstdb, callback) {
@@ -151,6 +131,7 @@ var extend = require('xtend')
       var type = ((op && op.keyEncoding) || options.keyEncoding) || 'utf8'
       return encodings[type] || type
     }
+
   , getValueEncoder = function (options, op) {
       var type = (((op && (op.valueEncoding || op.encoding))
           || options.valueEncoding || options.encoding)) || 'utf8'


### PR DESCRIPTION
Wouldn't mind an eye or two over this before I merge and publish. Shouldn't be anything really changed from #149 except for some minor style and redundancy fixes in levelup.js but util.js has a bit more serious work done where I've removed the now-redundant `encoders` and `decoders` and merged the difference into the new `encodings` stuff.

Tests pass, I just need a code review to make sure I'm not overlooking something silly.
