### PR TITLE
A ReadStream should support `destroy` to be called more than once.

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -89,6 +89,11 @@ ReadStream.prototype._read = function read () {
 }
 
 ReadStream.prototype._cleanup = function (err) {
+  if (this._destroyed)
+    return
+
+  this._destroyed = true
+
   var self = this
   if (err)
     self.emit('error', err)
@@ -100,7 +105,6 @@ ReadStream.prototype._cleanup = function (err) {
 }
 
 ReadStream.prototype.destroy = function () {
-  this._destroyed = true
   this._cleanup()
 }
 

--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -92,6 +92,37 @@ buster.testCase('ReadStream', {
       }.bind(this))
     }
 
+  , 'test destroy() after close': function (done) {
+      this.openTestDatabase(function (db) {
+        db.batch(this.sourceData.slice(), function (err) {
+          refute(err)
+
+          var rs = db.createReadStream()
+          rs.on('data' , this.dataSpy)
+          rs.on('end'  , this.endSpy)
+          rs.on('close', function () {
+            rs.destroy()
+            done()
+          }.bind(this))
+        }.bind(this))
+      }.bind(this))
+    }
+
+  , 'test destroy() twice': function (done) {
+      this.openTestDatabase(function (db) {
+        db.batch(this.sourceData.slice(), function (err) {
+          refute(err)
+
+          var rs = db.createReadStream()
+          rs.on('data' , function () {
+            rs.destroy()
+            rs.destroy()
+            done()
+          })
+        }.bind(this))
+      }.bind(this))
+    }
+
   , 'test destroy() half way through': function (done) {
       this.openTestDatabase(function (db) {
         db.batch(this.sourceData.slice(), function (err) {


### PR DESCRIPTION
This is related to https://github.com/mcollina/levelgraph/issues/37, and it is a regression against 0.14.0.
