### PR TITLE
DeferredLevelDOWN

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -8,6 +8,7 @@ var EventEmitter   = require('events').EventEmitter
   , inherits       = require('util').inherits
   , extend         = require('xtend')
   , prr            = require('prr')
+  , DeferredLevelDOWN = require('deferred-leveldown')
 
   , errors         = require('./errors')
   , ReadStream     = require('./read-stream')
@@ -90,16 +91,7 @@ LevelUP.prototype.open = function (callback) {
   this.emit('opening')
 
   this._status = 'opening'
-  this.db = [ 'get', 'put', 'batch', 'del', 'approximateSize' ]
-    .reduce(function (o, method) {
-      o[method] = function () {
-        var args = Array.prototype.slice.call(arguments)
-        self.once('ready', function () {
-          self.db[method].apply(self.db, args)
-        })
-      }
-      return o
-    }, {})
+  this.db = new DeferredLevelDOWN(this.location)
 
   dbFactory = this.options.db || getLevelDOWN()
   db        = dbFactory(this.location)
@@ -109,6 +101,7 @@ LevelUP.prototype.open = function (callback) {
       err = new errors.OpenError(err)
       return dispatchError(self, err, callback)
     } else {
+      self.db.setDb(db)
       self.db = db
       self._status = 'open'
       if (callback)

--- a/test/deferred-open-test.js
+++ b/test/deferred-open-test.js
@@ -144,7 +144,28 @@ buster.testCase('Deferred open()', {
       refute(db.isOpen())
       refute(db.isClosed())
     }
-    
+
+  , 'test deferred ReadStream': {
+        'setUp': common.readStreamSetUp
+
+      , 'simple ReadStream': function (done) {
+          this.openTestDatabase(function (db) {
+            var location = db.location
+            db.batch(this.sourceData.slice(), function (err) {
+              refute(err)
+              db.close(function (err) {
+                refute(err, 'no error')
+                db = levelup(location, { createIfMissing: false, errorIfExists: false })
+                var rs = db.createReadStream()
+                rs.on('data' , this.dataSpy)
+                rs.on('end'  , this.endSpy)
+                rs.on('close', this.verify.bind(this, rs, done))
+              }.bind(this))
+            }.bind(this))
+          }.bind(this))
+        }
+    }
+
   , 'maxListeners warning': function (done) {
       var location   = common.nextLocation()
       // 1) open database without callback, opens in worker thread


### PR DESCRIPTION
This PR is another approach to handling deferred-open and introduces [DeferredLevelDOWN](https://github.com/Level/deferred-leveldown) which is a very simple extension of [AbstractLevelDOWN](https://github.com/rvagg/node-abstract-leveldown) that simply queues operations until it's given a real LevelDOWN object.

The beauty of this approach is that AbstractLevelDOWN already implements the complete API semantics of LevelDOWN, argument checking and all so you even get proper `throw`s where LevelDOWN would throw (such as in the chained batch operations where you give bad args or call out of order).

This is an alternative to #182 but also removes the existing deferred open and should also fix #190 because there's only a single listener for `'ready'` (unless you make ReadStreams in which case there is a listener for each ReadStream&mdash;this is existing behaviour).

PR is against the 'expose' branch, see #193.
