### PR TITLE
optional location & options arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ db.put('name', 'LevelUP', function (err) {
 --------------------------------------------------------
 <a name="ctor"></a>
 ### levelup(location[, options[, callback]])
+### levelup(options[, callback ])
+### levelup(db[, callback ])
 <code>levelup()</code> is the main entry point for creating a new LevelUP instance and opening the underlying store with LevelDB.
 
 This function returns a new instance of LevelUP and will also initiate an <a href="#open"><code>open()</code></a> operation. Opening the database is an asynchronous operation which will trigger your callback if you provide one. The callback should take the form: `function (err, db) {}` where the `db` is the LevelUP instance. If you don't provide a callback, any read & write operations are simply queued internally until the database is fully opened.
@@ -157,6 +159,26 @@ db.get('foo', function (err, value) {
 ```
 
 The `location` argument is available as a read-only property on the returned LevelUP instance.
+
+The `levelup(options, callback)` form (with optional `callback`) is only available where you provide a valid `'db'` property on the options object (see below). Only for back-ends that don't require a `location` argument, such as [MemDOWN](https://github.com/rvagg/memdown).
+
+For example:
+
+```js
+var levelup = require('levelup')
+var memdown = require('memdown')
+var db = levelup({ db: memdown })
+```
+
+The `levelup(db, callback)` form (with optional `callback`) is only available where `db` is a factory function, as would be provided as a `'db'` property on an `options` object (see below). Only for back-ends that don't require a `location` argument, such as [MemDOWN](https://github.com/rvagg/memdown).
+
+For example:
+
+```js
+var levelup = require('levelup')
+var memdown = require('memdown')
+var db = levelup(memdown)
+```
 
 #### `options`
 

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -48,12 +48,21 @@ function LevelUP (location, options, callback) {
   EventEmitter.call(this)
   this.setMaxListeners(Infinity)
 
+  if (typeof location == 'function') {
+    options = typeof options == 'object' ? options : {}
+    options.db = location
+    location = null
+  } else if (typeof location == 'object' && typeof location.db == 'function') {
+    options = location
+    location = null
+  }
+
   if (typeof options == 'function') {
     callback = options
     options  = {}
   }
 
-  if (typeof location != 'string') {
+  if ((!options || typeof options.db != 'function') && typeof location != 'string') {
     error = new InitializationError(
         'Must provide a location for the database')
     if (callback) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       , "prr"                 : "~0.0.0"
       , "semver"              : "~1.1.4"
       , "bops"                : "~0.0.6"
-      , "deferred-leveldown"  : "~0.0.1"
+      , "deferred-leveldown"  : "~0.1.0"
     }
   , "devDependencies" : {
         "leveldown"       : "~0.9.0"

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -11,6 +11,7 @@ var levelup = require('../lib/levelup.js')
   , assert  = require('referee').assert
   , refute  = require('referee').refute
   , buster  = require('bustermove')
+  , MemDOWN = require('memdown')
 
 buster.testCase('Init & open()', {
     'setUp': common.commonSetUp
@@ -180,5 +181,37 @@ buster.testCase('Init & open()', {
           }.bind(this))
         }.bind(this))
       }.bind(this))
+    }
+
+  , 'constructor with options argument uses factory': function (done) {
+      var db = levelup({ db: MemDOWN })
+      assert.isNull(db.location, 'location property is null')
+      db.on('open', function () {
+        assert(db.db instanceof MemDOWN, 'using a memdown backend')
+        assert.same(db.db.location, '', 'db location property is ""')
+        db.put('foo', 'bar', function (err) {
+          refute(err, 'no error')
+          db.get('foo', function (err, value) {
+            assert.equals(value, 'bar', 'correct value')
+            done()
+          })
+        })
+      })
+    }
+
+  , 'constructor with only function argument uses factory': function (done) {
+      var db = levelup(MemDOWN)
+      assert.isNull(db.location, 'location property is null')
+      db.on('open', function () {
+        assert(db.db instanceof MemDOWN, 'using a memdown backend')
+        assert.same(db.db.location, '', 'db location property is ""')
+        db.put('foo', 'bar', function (err) {
+          refute(err, 'no error')
+          db.get('foo', function (err, value) {
+            assert.equals(value, 'bar', 'correct value')
+            done()
+          })
+        })
+      })
     }
 })


### PR DESCRIPTION
ref #206 as per @mmalecki's suggestion

This gives two new constructor forms: **levelup(options[, callback ])** and **levelup(db[, callback ])**.

If you don't provide a `location` argument but do provide an `'object'` as your first argument then it must have a `'db'` property that's a `'function'` which is assumed to be a backend factory; otherwise it fails. The second form is where you don't provide a `location` argument but you do provide a `'function'` as your first argument, this is assumed to be a back-end factory. In both cases a second argument is allowable, a callback `'function'` but this is optional. We can't do a form where you provide a `location` as the first argument and a back-end factory as the second because we can't tell if it's supposed to be a factory or a callback, unless you provide a callback as well, but then, you're getting verbose anyway so it's just silly.

``` js
var levelup = require('levelup')
var memdown = require('memdown')

var db = levelup({ db: memdown })

// or

var db = levelup(memdown) 
```

required new DeferredLevelDOWN and MemDOWN releases to make the `location` optional.
