### PR TITLE
db.batch().put() does not honor original options (like valueEncoding)

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -17,7 +17,7 @@ function Batch (levelup) {
 }
 
 Batch.prototype.put = function (key_, value_, options) {
-  options = getOptions(this, options)
+  options = getOptions(this._levelup, options)
 
   var key   = util.encodeKey(key_, options)
     , value = util.encodeValue(value_, options)
@@ -33,7 +33,7 @@ Batch.prototype.put = function (key_, value_, options) {
 }
 
 Batch.prototype.del = function (key_, options) {
-  options = getOptions(this, options)
+  options = getOptions(this._levelup, options)
 
   var key = util.encodeKey(key_, options)
 


### PR DESCRIPTION
I encountered this when using `valueEncoding: "utf8"` on the levelup constructor, and then running `db.batch().put().write()` -- my values were just the Object.toString().  All this does is make the batch API use the same options call that the main levelup path does.
