### PR TITLE
Remove bops, use Buffer instead

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -6,7 +6,6 @@
 
 var extend        = require('xtend')
   , LevelUPError  = require('./errors').LevelUPError
-  , bops          = require('bops')
 
   , encodingNames = [
         'hex'
@@ -33,7 +32,7 @@ var extend        = require('xtend')
 
   , encodings = (function () {
       function isBinary (data) {
-        return data === undefined || data === null || bops.is(data)
+        return data === undefined || data === null || Buffer.isBuffer(data)
       }
 
       var encodings = {}
@@ -41,7 +40,9 @@ var extend        = require('xtend')
           encode : function (data) {
             return isBinary(data) ? data : String(data)
           }
-        , decode : function (data) { return data }
+        , decode : function (data) {
+          return data
+          }
         , buffer : false
         , type   : 'utf8'
       }
@@ -56,10 +57,10 @@ var extend        = require('xtend')
           return
         encodings[type] = {
             encode : function (data) {
-              return isBinary(data) ? data : bops.from(data, type)
+              return isBinary(data) ? data : new Buffer(data, type)
             }
           , decode : function (buffer) {
-              return bops.from(buffer, type)
+              return process.browser ? buffer.toString(type) : buffer;
             }
           , buffer : true
           , type   : type // useful for debugging purposes

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "xtend": "~2.1.1",
     "prr": "~0.0.0",
     "semver": "~2.2.1",
-    "bops": "~0.1.0",
     "deferred-leveldown": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In PouchDB, we're attempting to get the MemDOWN plugin working in the browser as an alternative backend via leveldown (https://github.com/pouchdb/pouchdb/pull/2063, https://github.com/pouchdb/pouchdb/issues/1767).  Apparently bops is a no-go for the browser, so this replaces bops with Buffer.

Our own browser tests are passing, and in this project when I do npm test, it's all clear.  The one thing I'm unsure about is the `decode` line; it makes no sense to me why we'd want to return a string in the browser but a Buffer in Node.

So basically some guidance here would be much appreciated, but I think this PR is a good start, anyway.
