### PR TITLE
Fix race condition on read stream's self._iterator

### DIFF
--- a/lib/read-stream.js
+++ b/lib/read-stream.js
@@ -60,7 +60,9 @@ function ReadStream (options, db, iteratorFactory) {
   var self = this
   if (!this._db.isOpen()) {
     this._db.once('ready', function () {
-      self._iterator = iteratorFactory(self._options)
+      if (!self._destroyed) {
+        self._iterator = iteratorFactory(self._options)
+      }
     })
   } else
     this._iterator = iteratorFactory(this._options)
@@ -103,10 +105,14 @@ ReadStream.prototype._cleanup = function (err) {
   if (err)
     self.emit('error', err)
 
-  self._iterator.end(function () {
-    self._iterator = null
+  if (self._iterator) {
+    self._iterator.end(function () {
+      self._iterator = null
+      self.emit('close')
+    })
+  } else {
     self.emit('close')
-  })
+  }
 }
 
 ReadStream.prototype.destroy = function () {

--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -108,6 +108,19 @@ buster.testCase('ReadStream', {
       }.bind(this))
     }
 
+  , 'test destroy() after closing db': function (done) {
+    this.openTestDatabase(function (db) {
+      db.batch(this.sourceData.slice(), function (err) {
+        refute(err)
+        db.close(function (err) {
+          var rs = db.createReadStream()
+          rs.destroy()
+          done()
+        }.bind(this))
+      }.bind(this))
+    }.bind(this))
+  }
+
   , 'test destroy() twice': function (done) {
       this.openTestDatabase(function (db) {
         db.batch(this.sourceData.slice(), function (err) {


### PR DESCRIPTION
This is a really tricky bug to reproduce, but when testing PouchDB as a client against PouchDB as a server, I can reproduce it pretty consistently. Details here: https://github.com/nick-thompson/express-pouchdb/issues/38.

Since it's a race condition, I don't think there's a unit test I can write that can catch it, but just mentally walking through the code, it seems to me that what happens is this:
1. ReadStream constructor is called
2. ReadmStream `_cleanup` is called, but `self._iterator` hasn't been set yet (hence TypeError) 
3. `self._iterator = iteratorFactory(self._options)` is called within the `this._db.once('ready')` callback, so now `self._iterator` is set, but it's too late

You can repro it yourself by running the PouchDB tests in question.  Sorry for the messy steps, but here they are:

```
git clone --depth 1 -b 2281 https://github.com/pouchdb/pouchdb.git
git clone --depth 1 https://github.com/nick-thompson/pouchdb-server.git
git clone --depth 1 -b working-version https://github.com/nolanlawson/express-pouchdb.git
cd pouchdb && npm install
cd ../express-pouchdb && npm link ../pouchdb
cd ../pouchdb-server && npm link ../express-pouchdb
cd ../pouchdb && npm link ../pouchdb-server
npm install
SERVER=pouchdb-server npm test
```

Note that the tests still fail after the fix, but that's due to another bug on our end; nothing for you folks to worry about.  :)

I'm using Node v0.10.28.
