### PR TITLE
replace concat-stream with bl, fixes #251

### DIFF
--- a/lib/write-stream.js
+++ b/lib/write-stream.js
@@ -7,7 +7,7 @@
 var Stream       = require('stream').Stream
   , inherits     = require('util').inherits
   , extend       = require('xtend')
-  , concatStream = require('concat-stream')
+  , bl           = require('bl')
 
   , setImmediate = global.setImmediate || process.nextTick
 
@@ -157,7 +157,7 @@ WriteStream.prototype._write = function (entry) {
   if (!key)
     return
 
-  entry.pipe(concatStream(function (err, data) {
+  entry.pipe(bl(function (err, data) {
     if (err) {
       self.writable = false
       return self.emit('error', err)
@@ -167,7 +167,7 @@ WriteStream.prototype._write = function (entry) {
         key.indexOf(self._options.fstreamRoot) > -1)
       key = key.substr(self._options.fstreamRoot.length + 1)
 
-    self.write({ key: key, value: data })
+    self.write({ key: key, value: data.slice() })
   }))
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   ],
   "main": "lib/levelup.js",
   "dependencies": {
-    "concat-stream": "~1.4.6",
+    "bl": "~0.8.0",
     "deferred-leveldown": "~0.2.0",
     "errno": "~0.1.1",
     "prr": "~0.0.0",


### PR DESCRIPTION
quick sanity check from someone for this please and I'll do a patch release, the arguments change to concat-stream is kind of annoying and it doesn't deal with `err` properly anyway while **bl** does.
