### PR TITLE
update README to reflect level as recommended way to install levelup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,11 @@ LevelDOWN is now optional because LevelUP can be used with alternative backends,
 
 LevelUP will look for LevelDOWN and throw an error if it can't find it in its Node `require()` path. It will also tell you if the installed version of LevelDOWN is incompatible.
 
-**The [level](https://github.com/level/level) package is available as an alternative installation mechanism.** Install it instead to automatically get both LevelUP & LevelDOWN. It exposes LevelUP on its export (i.e. you can `var leveldb = require('level')`).
+**The recommended way is using the [level](https://github.com/level/level) package.** Install it to automatically get both LevelUP and LevelDOWN. It knows which versions of LevelUP and LevelDOWN that goes well together and exposes LevelUP on its export:
+
+```js
+var leveldb = require('level')
+```
 
 
 <a name="platforms"></a>
@@ -67,17 +71,13 @@ Basic usage
 First you need to install LevelUP!
 
 ```sh
-$ npm install levelup leveldown
+$ npm install level
 ```
-
 Or
 
 ```sh
-$ npm install level
+$ npm install levelup leveldown
 ```
-
-*(this second option requires you to use LevelUP by calling `var levelup = require('level')`)*
-
 
 All operations are asynchronous although they don't necessarily require a callback if you don't need to know when the operation was performed.
 


### PR DESCRIPTION
The other day we had an issue (https://github.com/rvagg/node-levelup/issues/282) where the version of `levelup` and `leveldown` was not in sync.

To avoid these things in the future I think we should let people know that `level` is the recommended way of installing `levelup` and not just an alternative.
