### PR TITLE
Use newer memdown store. Fixes build.

### DIFF
--- a/test/leveldown-substitution-test.js
+++ b/test/leveldown-substitution-test.js
@@ -46,7 +46,7 @@ buster.testCase('LevelDOWN Substitution', {
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._keys
+              md._store['$foo'].keys
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )


### PR DESCRIPTION
This uses the `_store` property present in recent versions of memdown to test that the keys are present in memdown. Should fix the travis build.
