### PR TITLE
levelup from already-created leveldown

### DIFF
--- a/lib/is-leveldown.js
+++ b/lib/is-leveldown.js
@@ -1,0 +1,7 @@
+module.exports = function (db) {
+  if (!db || typeof db !== 'object') return false
+  return typeof db.iterator === 'function'
+    && typeof db.get === 'function'
+    && typeof db.put === 'function'
+    && typeof db.batch === 'function'
+}

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -22,6 +22,7 @@ var EventEmitter   = require('events').EventEmitter
   , util           = require('./util')
   , Batch          = require('./batch')
   , codec          = require('./codec')
+  , isLevelDOWN    = require('./is-leveldown')
 
   , getOptions     = util.getOptions
   , defaultOptions = util.defaultOptions
@@ -45,17 +46,27 @@ function LevelUP (location, options, callback) {
   if (!(this instanceof LevelUP))
     return new LevelUP(location, options, callback)
 
-  var error
+  var error, down
 
   EventEmitter.call(this)
   this.setMaxListeners(Infinity)
 
-  if (typeof location == 'function') {
+  if (isLevelDOWN(location)) {
+    options = typeof options == 'object' ? options : {}
+    down = location
+    options.db = function () { return down }
+    location = null
+  } else if (typeof location == 'function') {
     options = typeof options == 'object' ? options : {}
     options.db = location
     location = null
   } else if (typeof location == 'object' && typeof location.db == 'function') {
     options = location
+    location = null
+  } else if (typeof location === 'object' && isLevelDOWN(location.db)) {
+    options = location
+    down = options.db
+    options.db = function () { return down } 
     location = null
   }
 

--- a/test/levelup-from-leveldown.js
+++ b/test/levelup-from-leveldown.js
@@ -1,0 +1,55 @@
+/* Copyright (c) 2012-2014 LevelUP contributors
+ * See list at <https://github.com/rvagg/node-levelup#contributing>
+ * MIT License <https://github.com/rvagg/node-levelup/blob/master/LICENSE.md>
+ */
+
+var levelup = require('../lib/levelup.js')
+  , assert  = require('referee').assert
+  , refute  = require('referee').refute
+  , buster  = require('bustermove')
+  , MemDOWN = require('memdown')
+
+require('./common')
+
+buster.testCase('levelup from leveldown', {
+    'levelup from leveldown in location slot': function (done) {
+      var md       = new MemDOWN('foo')
+        , db       = levelup(md)
+        , entries  = []
+        , expected = [
+              { key: 'a', value: 'A' }
+            , { key: 'b', value: 'B' }
+            , { key: 'c', value: 'C' }
+            , { key: 'd', value: 'D' }
+            , { key: 'e', value: 'E' }
+            , { key: 'f', value: 'F' }
+            , { key: 'i', value: 'I' }
+          ]
+
+      db.put('f', 'F')
+      db.put('h', 'H')
+      db.put('i', 'I')
+      db.put('a', 'A')
+      db.put('c', 'C')
+      db.put('e', 'E')
+      db.del('g')
+      db.batch([
+          { type: 'put', key: 'd', value: 'D' }
+        , { type: 'del', key: 'h' }
+        , { type: 'put', key: 'b', value: 'B' }
+      ])
+
+      db.createReadStream()
+        .on('data', function (data) { entries.push(data) })
+        .on('error', function (err) { refute(err, 'readStream emitted an error') })
+        .on('close', function () {
+          assert.equals(entries, expected, 'correct entries')
+          assert.equals(
+              md._store['$foo'].keys
+            , expected.map(function (e) { return e.key })
+            , 'memdown has the entries'
+          )
+          done()
+        })
+    }
+})

--- a/test/levelup-from-leveldown.js
+++ b/test/levelup-from-leveldown.js
@@ -125,11 +125,11 @@ buster.testCase('levelup from leveldown', {
       ])
       db.createReadStream()
         .on('data', function (data) { entries.push(data) })
-        //.on('error', function (err) { refute(err, 'readStream emitted an error') })
+        .on('error', function (err) { refute(err, 'readStream emitted an error') })
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._store['$foo2'].keys
+              md._store['$foo2'].keys.map(function (e) { return e + '!D' })
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )
@@ -173,7 +173,7 @@ buster.testCase('levelup from leveldown', {
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._store['$foo3'].keys
+              md._store['$foo3'].keys.map(function (e) { return e + '!D' })
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )

--- a/test/levelup-from-leveldown.js
+++ b/test/levelup-from-leveldown.js
@@ -13,7 +13,7 @@ require('./common')
 
 buster.testCase('levelup from leveldown', {
     'levelup from leveldown in location slot': function (done) {
-      var md       = new MemDOWN('foo')
+      var md       = new MemDOWN('foo0')
         , db       = levelup(md)
         , entries  = []
         , expected = [
@@ -45,7 +45,7 @@ buster.testCase('levelup from leveldown', {
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._store['$foo'].keys
+              md._store['$foo0'].keys
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )
@@ -53,7 +53,7 @@ buster.testCase('levelup from leveldown', {
         })
     },
     'levelup from leveldown in options.db slot': function (done) {
-      var md       = new MemDOWN('foo')
+      var md       = new MemDOWN('foo1')
         , db       = levelup({ db: md })
         , entries  = []
         , expected = [
@@ -85,7 +85,7 @@ buster.testCase('levelup from leveldown', {
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._store['$foo'].keys
+              md._store['$foo1'].keys
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )
@@ -93,7 +93,7 @@ buster.testCase('levelup from leveldown', {
         })
     },
     'levelup from leveldown in options.db slot with encodings': function (done) {
-      var md       = new MemDOWN('foo')
+      var md       = new MemDOWN('foo2')
         , kenc     = {
               encode: function (s) { return Buffer(s + '!E') }
             , decode: function (s) { return s.toString() + '!D' }
@@ -125,11 +125,11 @@ buster.testCase('levelup from leveldown', {
       ])
       db.createReadStream()
         .on('data', function (data) { entries.push(data) })
-        .on('error', function (err) { refute(err, 'readStream emitted an error') })
+        //.on('error', function (err) { refute(err, 'readStream emitted an error') })
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._store['$foo'].keys
+              md._store['$foo2'].keys
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )
@@ -137,7 +137,7 @@ buster.testCase('levelup from leveldown', {
         })
     },
     'levelup from leveldown in location slot with encodings': function (done) {
-      var md       = new MemDOWN('foo')
+      var md       = new MemDOWN('foo3')
         , kenc     = {
               encode: function (s) { return Buffer(s + '!E') }
             , decode: function (s) { return s.toString() + '!D' }
@@ -173,7 +173,7 @@ buster.testCase('levelup from leveldown', {
         .on('close', function () {
           assert.equals(entries, expected, 'correct entries')
           assert.equals(
-              md._store['$foo'].keys
+              md._store['$foo3'].keys
             , expected.map(function (e) { return e.key })
             , 'memdown has the entries'
           )

--- a/test/levelup-from-leveldown.js
+++ b/test/levelup-from-leveldown.js
@@ -51,5 +51,45 @@ buster.testCase('levelup from leveldown', {
           )
           done()
         })
-    }
+    },
+    'levelup from leveldown in options.db slot': function (done) {
+      var md       = new MemDOWN('foo')
+        , db       = levelup({ db: md })
+        , entries  = []
+        , expected = [
+              { key: 'a', value: 'A' }
+            , { key: 'b', value: 'B' }
+            , { key: 'c', value: 'C' }
+            , { key: 'd', value: 'D' }
+            , { key: 'e', value: 'E' }
+            , { key: 'f', value: 'F' }
+            , { key: 'i', value: 'I' }
+          ]
+
+      db.put('f', 'F')
+      db.put('h', 'H')
+      db.put('i', 'I')
+      db.put('a', 'A')
+      db.put('c', 'C')
+      db.put('e', 'E')
+      db.del('g')
+      db.batch([
+          { type: 'put', key: 'd', value: 'D' }
+        , { type: 'del', key: 'h' }
+        , { type: 'put', key: 'b', value: 'B' }
+      ])
+
+      db.createReadStream()
+        .on('data', function (data) { entries.push(data) })
+        .on('error', function (err) { refute(err, 'readStream emitted an error') })
+        .on('close', function () {
+          assert.equals(entries, expected, 'correct entries')
+          assert.equals(
+              md._store['$foo'].keys
+            , expected.map(function (e) { return e.key })
+            , 'memdown has the entries'
+          )
+          done()
+        })
+    },
 })

--- a/test/levelup-from-leveldown.js
+++ b/test/levelup-from-leveldown.js
@@ -92,4 +92,48 @@ buster.testCase('levelup from leveldown', {
           done()
         })
     },
+    'levelup from leveldown in location slot with encodings': function (done) {
+      var md       = new MemDOWN('foo')
+        , kenc     = {
+              encode: function (s) { return Buffer(s + '!E') }
+            , decode: function (s) { return s.toString() + '!D' }
+          }
+        , opts     = { db: md, keyEncoding: kenc, valueEncoding: 'json' }
+        , db       = levelup(opts)
+        , entries  = []
+        , expected = [
+              { key: 'a!E!D', value: [1,2] }
+            , { key: 'b!E!D', value: {x:3,y:4} }
+            , { key: 'c!E!D', value: 'C' }
+            , { key: 'd!E!D', value: 'D' }
+            , { key: 'e!E!D', value: 'E' }
+            , { key: 'f!E!D', value: 'F' }
+            , { key: 'i!E!D', value: 'I' }
+          ]
+
+      db.put('f', 'F')
+      db.put('h', 'H')
+      db.put('i', 'I')
+      db.put('a', [1,2])
+      db.put('c', 'C')
+      db.put('e', 'E')
+      db.del('g')
+      db.batch([
+          { type: 'put', key: 'd', value: 'D' }
+        , { type: 'del', key: 'h' }
+        , { type: 'put', key: 'b', value: {x:3,y:4} }
+      ])
+      db.createReadStream()
+        .on('data', function (data) { entries.push(data) })
+        .on('error', function (err) { refute(err, 'readStream emitted an error') })
+        .on('close', function () {
+          assert.equals(entries, expected, 'correct entries')
+          assert.equals(
+              md._store['$foo'].keys
+            , expected.map(function (e) { return e.key })
+            , 'memdown has the entries'
+          )
+          done()
+        })
+    },
 })


### PR DESCRIPTION
The documentation would seem to suggest that you can pass in an `opts.db` leveldown object:

* `'db'` *(object, default: LevelDOWN)*: LevelUP is backed by [LevelDOWN](https://github.com/rvagg/node-leveldown/) to provide an interface to LevelDB.

It also mentions that db can be a constructor, but it doesn't mention that this is the only way to create a levelup from a leveldown. Currently if you already have a leveldown instance you've got to do:

``` js
var levelup = require('levelup');
var leveldown = require('leveldown');

var down = leveldown('./whatever.db');
var up = levelup({ db: function () { return down });
```

which is pretty strange since levelup instances are 1:1 with leveldown instances. I really don't see the benefit in passing a constructor function at all. It seems like it should be levelup's job to just upgrade existing leveldown instances, not to instantiate leveldown instances from a constructor with a location.

This patch makes the following work like the documentation suggests it should work:

``` js
var levelup = require('levelup');
var leveldown = require('leveldown');

var down = leveldown('./whatever.db');
var up = levelup({ db: down });
```

The documentation also says:

``` md
### levelup(db[, callback ])
```

which would appear to suggest that you can do `levelup(down)`, but that doesn't actually work.
This patch also adds support for this already-documented form:

``` js
var levelup = require('levelup');
var leveldown = require('leveldown');

var down = leveldown('./whatever.db');
var up = levelup(down);
```

or you could just do:

``` js
var levelup = require('levelup');
var leveldown = require('leveldown');

var db = levelup(leveldown('./whatever.db'));
```

These forms to me seem much closer to the intent of levelup: to wrap features such as encodings and createReadStream on top of a leveldown.

Further out, I'm not really sure what the location property is doing in there at all or what it's for. It seems like handling a location path should be leveldown's job, not levelup. Plus there are more ways to specify a "location" than a simple string value, which leveldowns will be better at providing given their unique specializations.