### PR TITLE
remove .approximateSize()

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -6,6 +6,7 @@
 
 var EventEmitter        = require('events').EventEmitter
   , inherits            = require('util').inherits
+  , deprecate           = require('util').deprecate
   , extend              = require('xtend')
   , prr                 = require('prr')
   , DeferredLevelDOWN   = require('deferred-leveldown')
@@ -317,31 +318,30 @@ LevelUP.prototype.batch = function (arr_, options, callback) {
   })
 }
 
-// DEPRECATED: prefer accessing LevelDOWN for this: db.db.approximateSize()
-LevelUP.prototype.approximateSize = function (start_, end_, options, callback) {
-  var self = this
-    , start
-    , end
-
-  callback = getCallback(options, callback)
-
-  options = getOptions(options)
-
-  if (start_ === null || start_ === undefined
-        || end_ === null || end_ === undefined || 'function' !== typeof callback)
-    return readError(this, 'approximateSize() requires start, end and callback arguments', callback)
-
-  start = this._codec.encodeKey(start_, options)
-  end   = this._codec.encodeKey(end_, options)
-
-  this.db.approximateSize(start, end, function (err, size) {
-    if (err) {
-      return dispatchError(self, new OpenError(err), callback)
-    } else if (callback) {
-      callback(null, size)
-    }
-  })
-}
+LevelUP.prototype.approximateSize = deprecate(function (start_, end_, options, callback) {   
+  var self = this    
+    , start    
+    , end    
+   
+  callback = getCallback(options, callback)    
+   
+  options = getOptions(options)    
+   
+  if (start_ === null || start_ === undefined    
+        || end_ === null || end_ === undefined || 'function' !== typeof callback)    
+    return readError(this, 'approximateSize() requires start, end and callback arguments', callback)   
+   
+  start = this._codec.encodeKey(start_, options)   
+  end   = this._codec.encodeKey(end_, options)   
+   
+  this.db.approximateSize(start, end, function (err, size) {   
+    if (err) {   
+      return dispatchError(self, new OpenError(err), callback)   
+    } else if (callback) {   
+      callback(null, size)   
+    }    
+  })   
+}, 'db.approximateSize() is deprecated. Use db.db.approximateSize() instead')
 
 LevelUP.prototype.readStream =
 LevelUP.prototype.createReadStream = function (options) {

--- a/test/appromixate-size-test.js
+++ b/test/appromixate-size-test.js
@@ -15,6 +15,18 @@ buster.testCase('approximateSize()', {
     'setUp': common.commonSetUp
   , 'tearDown': common.commonTearDown
 
+  , 'approximateSize() is deprecated': function (done) {
+      this.openTestDatabase(function (db) {
+        var error = console.error
+        console.error = function(str){
+          console.error = error
+          assert.equals(str, 'db.approximateSize() is deprecated. Use db.db.approximateSize() instead')
+          done()
+        }
+        db.approximateSize('a', 'z', function(){})
+      })
+    }
+
   , 'approximateSize() works on empty database': function (done) {
       this.openTestDatabase(function (db) {
         db.approximateSize('a', 'z', function(err, size) {

--- a/test/get-put-del-test.js
+++ b/test/get-put-del-test.js
@@ -147,34 +147,4 @@ buster.testCase('get() / put() / del()', {
       })
     }
 
-  , 'test approximateSize() throwables': function (done) {
-      this.openTestDatabase(function (db) {
-
-        assert.exception(
-            db.approximateSize.bind(db)
-          , { name: 'ReadError', message: 'approximateSize() requires start, end and callback arguments' }
-          , 'no-arg approximateSize() throws'
-        )
-
-        assert.exception(
-            db.approximateSize.bind(db, 'foo')
-          , { name: 'ReadError', message: 'approximateSize() requires start, end and callback arguments' }
-          , 'callback-less, 1-arg approximateSize() throws'
-        )
-
-        assert.exception(
-            db.approximateSize.bind(db, 'foo', 'bar')
-          , { name: 'ReadError', message: 'approximateSize() requires start, end and callback arguments' }
-          , 'callback-less, 2-arg approximateSize() throws'
-        )
-
-        assert.exception(
-            db.approximateSize.bind(db, 'foo', 'bar', {})
-          , { name: 'ReadError', message: 'approximateSize() requires start, end and callback arguments' }
-          , 'callback-less, 3-arg approximateSize(), no cb throws'
-        )
-
-        done()
-      })
-    }
 })


### PR DESCRIPTION
Since it has been undocumented for a while and we're about to make a major release.

We can also use [util.deprecate](https://iojs.org/api/util.html#util_util_deprecate_function_string) first, but I'd prefer plain removing it.