### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,13 @@
   ],
   "main": "lib/levelup.js",
   "dependencies": {
-    "deferred-leveldown": "^0.3.0",
-    "level-codec": "^5.0.0",
+    "deferred-leveldown": "~1.0.0",
+    "level-codec": "~5.5.0",
     "level-errors": "~1.0.3",
-    "prr": "~0.0.0",
+    "prr": "~1.0.1",
     "readable-stream": "~1.0.26",
-    "semver": "~2.3.1",
-    "xtend": "~3.0.0"
+    "semver": "~4.3.3",
+    "xtend": "~4.0.0"
   },
   "devDependencies": {
     "async": "~0.9.0",
@@ -51,7 +51,7 @@
     "memdown": "~1.0.0",
     "msgpack-js": "~0.3.0",
     "referee": "~1.1.1",
-    "rimraf": "~2.2.8",
+    "rimraf": "~2.3.2",
     "tap": "~0.4.13",
     "slow-stream": "0.0.4"
   },


### PR DESCRIPTION
Most important thing here imo is `deferred-leveldown@1.0.0` (`deferred-leveldown` should use the same `abstract-leveldown` as `leveldown` does). Only outdated module now is `tap`. I can't update to latest because npm complains when installing `bustermove`, but I don't think that matters that much.