### PR TITLE
Remove location argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ var levelup   = require('levelup')
 
 // 1) Create our database, supply location and options.
 //    This will create or open the underlying LevelDB store.
-var db = levelup('./mydb', { db: leveldown })
+var db = levelup(leveldown('./mydb'))
 
 // 2) put a key & value
 db.put('name', 'LevelUP', function (err) {
@@ -133,9 +133,7 @@ db.put('name', 'LevelUP', function (err) {
 
 --------------------------------------------------------
 <a name="ctor"></a>
-### levelup(location, options[, callback]])
-### levelup(options[, callback ])
-### levelup(db[, callback ])
+### levelup(db[, options][, callback]])
 <code>levelup()</code> is the main entry point for creating a new LevelUP instance and opening the underlying store with LevelDB.
 
 This function returns a new instance of LevelUP and will also initiate an <a href="#open"><code>open()</code></a> operation. Opening the database is an asynchronous operation which will trigger your callback if you provide one. The callback should take the form: `function (err, db) {}` where the `db` is the LevelUP instance. If you don't provide a callback, any read & write operations are simply queued internally until the database is fully opened.
@@ -143,7 +141,7 @@ This function returns a new instance of LevelUP and will also initiate an <a hre
 This leads to two alternative ways of managing a new LevelUP instance:
 
 ```js
-levelup(location, options, function (err, db) {
+levelup(leveldown(location), function (err, db) {
   if (err) throw err
   db.get('foo', function (err, value) {
     if (err) return console.log('foo does not exist')
@@ -153,33 +151,11 @@ levelup(location, options, function (err, db) {
 
 // vs the equivalent:
 
-var db = levelup(location, options) // will throw if an error occurs
+var db = levelup(leveldown(location)) // will throw if an error occurs
 db.get('foo', function (err, value) {
   if (err) return console.log('foo does not exist')
   console.log('got foo =', value)
 })
-```
-
-The `location` argument is available as a read-only property on the returned LevelUP instance.
-
-The `levelup(options, callback)` form (with optional `callback`) is only available where you provide a valid `'db'` property on the options object (see below). Only for back-ends that don't require a `location` argument, such as [MemDOWN](https://github.com/level/memdown).
-
-For example:
-
-```js
-var levelup = require('levelup')
-var memdown = require('memdown')
-var db = levelup({ db: memdown })
-```
-
-The `levelup(db, callback)` form (with optional `callback`) is only available where `db` is a factory function, as would be provided as a `'db'` property on an `options` object (see below). Only for back-ends that don't require a `location` argument, such as [MemDOWN](https://github.com/level/memdown).
-
-For example:
-
-```js
-var levelup = require('levelup')
-var memdown = require('memdown')
-var db = levelup(memdown)
 ```
 
 #### `options`
@@ -194,8 +170,6 @@ var db = levelup(memdown)
   <p><code>'utf8'</code> is the default encoding for both keys and values so you can simply pass in strings and expect strings from your <code>get()</code> operations. You can also pass <code>Buffer</code> objects as keys and/or values and conversion will be performed.</p>
   <p>Supported encodings are: hex, utf8, ascii, binary, base64, ucs2, utf16le.</p>
   <p><code>'json'</code> encoding is also supported, see below.</p>
-
-* `'db'` *(object, default: LevelDOWN)*: LevelUP is backed by [LevelDOWN](https://github.com/level/leveldown/) to provide an interface to LevelDB. You can completely replace the use of LevelDOWN by providing a "factory" function that will return a LevelDOWN API compatible object given a `location` argument. For further information, see [MemDOWN](https://github.com/level/memdown), a fully LevelDOWN API compatible replacement that uses a memory store rather than LevelDB. Also see [Abstract LevelDOWN](http://github.com/level/abstract-leveldown), a partial implementation of the LevelDOWN API that can be used as a base prototype for a LevelDOWN substitute.
 
 Additionally, each of the main interface methods accept an optional options object that can be used to override `'keyEncoding'` and `'valueEncoding'`.
 

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -115,14 +115,13 @@ LevelUP.prototype.close = function (callback) {
   var self = this
 
   if (this.isOpen()) {
-    this.db.close(function (err) {
-      if (err) return callback(err)
-      self.db = new DeferredLevelDOWN(self._db)
+    this.db.close(function () {
       self.emit('closed')
       if (callback)
         callback.apply(null, arguments)
     })
     this.emit('closing')
+    this.db = new DeferredLevelDOWN(this._db)
   } else if (this.isClosed() && callback) {
     return process.nextTick(callback)
   } else if (this.db.status == 'closing' && callback) {

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -28,12 +28,13 @@ var EventEmitter        = require('events').EventEmitter
   , getLevelDOWN        = util.getLevelDOWN
   , dispatchError       = util.dispatchError
   , isDefined           = util.isDefined
+  , validateDOWN        = util.validateDOWN
 
 function getCallback (options, callback) {
   return typeof options == 'function' ? options : callback
 }
 
-// Possible LevelUP#_status values:
+// Possible LevelDOWN#status values:
 //  - 'new'     - newly created, not opened or closed
 //  - 'opening' - waiting for the database to be opened, post open()
 //  - 'open'    - successfully opened the database, available for use
@@ -41,41 +42,24 @@ function getCallback (options, callback) {
 //  - 'closed'  - database has been successfully closed, should not be
 //                 used except for another open() operation
 
-function LevelUP (location, options, callback) {
+function LevelUP (db, options, callback) {
   if (!(this instanceof LevelUP))
-    return new LevelUP(location, options, callback)
+    return new LevelUP(db, options, callback)
 
   var error
 
   EventEmitter.call(this)
   this.setMaxListeners(Infinity)
 
-  if (typeof location == 'function') {
-    options = typeof options == 'object' ? options : {}
-    options.db = location
-    location = null
-  } else if (typeof location == 'object' && typeof location.db == 'function') {
-    options = location
-    location = null
-  }
-
-
   if (typeof options == 'function') {
     callback = options
     options  = {}
   }
+  options = options || {}
 
-  if (!options && typeof options.db != 'function') {
+  if (!db || typeof db != 'object') {
     error = new InitializationError(
-        'Must provide .db')
-  }
-
-  if (!error && (!options || typeof options.db != 'function') && typeof location != 'string') {
-    error = new InitializationError(
-        'Must provide a location for the database')
-  }
-
-  if (error) {
+        'Must provide db')
     if (callback) {
       return process.nextTick(function () {
         callback(error)
@@ -83,14 +67,13 @@ function LevelUP (location, options, callback) {
     }
     throw error
   }
+  validateDOWN(db)
 
   options      = getOptions(options)
   this.options = extend(defaultOptions, options)
   this._codec = new Codec(this.options)
-  this._status = 'new'
-  // set this.location as enumerable but not configurable or writable
-  prr(this, 'location', location, 'e')
 
+  this.db      = new DeferredLevelDOWN(db)
   this.open(callback)
 }
 
@@ -98,7 +81,6 @@ inherits(LevelUP, EventEmitter)
 
 LevelUP.prototype.open = function (callback) {
   var self = this
-    , db
 
   if (this.isOpen()) {
     if (callback)
@@ -115,17 +97,18 @@ LevelUP.prototype.open = function (callback) {
 
   this.emit('opening')
 
-  this._status = 'opening'
-  this.db      = new DeferredLevelDOWN(this.location)
-  db           = this.options.db(this.location)
-
-  db.open(this.options, function (err) {
+  this.db.open(this.options, function (err) {
     if (err) {
       return dispatchError(self, new OpenError(err), callback)
     } else {
-      self.db.setDb(db)
+      var db = self.db._db
+      try {
+        validateDOWN(db)
+      } catch (err) {
+        return dispatchError(self, err, callback)
+      }
+
       self.db = db
-      self._status = 'open'
       if (callback)
         callback(null, self)
       self.emit('open')
@@ -138,18 +121,17 @@ LevelUP.prototype.close = function (callback) {
   var self = this
 
   if (this.isOpen()) {
-    this._status = 'closing'
-    this.db.close(function () {
-      self._status = 'closed'
+    this.db.close(function (err) {
+      if (err) return callback(err)
+      self.db = new DeferredLevelDOWN(self.db)
       self.emit('closed')
       if (callback)
         callback.apply(null, arguments)
     })
     this.emit('closing')
-    this.db = new DeferredLevelDOWN(this.location)
-  } else if (this._status == 'closed' && callback) {
+  } else if (this.isClosed() && callback) {
     return process.nextTick(callback)
-  } else if (this._status == 'closing' && callback) {
+  } else if (this.db.status == 'closing' && callback) {
     this.once('closed', callback)
   } else if (this._isOpening()) {
     this.once('open', function () {
@@ -159,15 +141,15 @@ LevelUP.prototype.close = function (callback) {
 }
 
 LevelUP.prototype.isOpen = function () {
-  return this._status == 'open'
+  return this.db.status == 'open'
 }
 
 LevelUP.prototype._isOpening = function () {
-  return this._status == 'opening'
+  return this.db.status == 'opening'
 }
 
 LevelUP.prototype.isClosed = function () {
-  return (/^clos/).test(this._status)
+  return (/^clos|new/).test(this.db.status)
 }
 
 function maybeError(db, callback) {

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -73,6 +73,7 @@ function LevelUP (db, options, callback) {
   this.options = extend(defaultOptions, options)
   this._codec = new Codec(this.options)
 
+  this._db     = db
   this.db      = new DeferredLevelDOWN(db)
   this.open(callback)
 }
@@ -101,7 +102,7 @@ LevelUP.prototype.open = function (callback) {
     if (err) {
       return dispatchError(self, new OpenError(err), callback)
     } else {
-      self.db = self.db._db
+      self.db = self._db
       if (callback)
         callback(null, self)
       self.emit('open')
@@ -116,7 +117,7 @@ LevelUP.prototype.close = function (callback) {
   if (this.isOpen()) {
     this.db.close(function (err) {
       if (err) return callback(err)
-      self.db = new DeferredLevelDOWN(self.db)
+      self.db = new DeferredLevelDOWN(self._db)
       self.emit('closed')
       if (callback)
         callback.apply(null, arguments)

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -101,14 +101,7 @@ LevelUP.prototype.open = function (callback) {
     if (err) {
       return dispatchError(self, new OpenError(err), callback)
     } else {
-      var db = self.db._db
-      try {
-        validateDOWN(db)
-      } catch (err) {
-        return dispatchError(self, err, callback)
-      }
-
-      self.db = db
+      self.db = self.db._db
       if (callback)
         callback(null, self)
       self.emit('open')

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,6 +5,7 @@
  */
 
 var extend        = require('xtend')
+  , assert        = require('assert')
   , defaultOptions = {
         keyEncoding     : 'utf8'
       , valueEncoding   : 'utf8'
@@ -29,9 +30,16 @@ function isDefined (v) {
   return typeof v !== 'undefined'
 }
 
+function validateDOWN (db) {
+  assert(db.status,
+    '.status required. upgrade your backend / its abstract-leveldown dependency'
+  )
+}
+
 module.exports = {
     defaultOptions  : defaultOptions
   , getOptions      : getOptions
   , dispatchError   : dispatchError
   , isDefined       : isDefined
+  , validateDOWN    : validateDOWN
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   ],
   "main": "lib/levelup.js",
   "dependencies": {
-    "deferred-leveldown": "~1.0.0",
+    "deferred-leveldown": "^2.0.0-2",
     "level-codec": "~6.0.0",
     "level-errors": "~1.0.3",
     "level-iterator-stream": "~1.3.0",

--- a/test/benchmarks/engines/levelup-nosnappy.js
+++ b/test/benchmarks/engines/levelup-nosnappy.js
@@ -3,7 +3,8 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../../../')
+var levelup   = require('../../../')
+  , leveldown = require('leveldown')
 
   , createDb = function (location, callback) {
       levelup(location, { compression: false }, function (err, db) {
@@ -11,7 +12,7 @@ var levelup = require('../../../')
       })
     }
 
-  , closeDb = function (db, callback) {
+  , closeDb  = function (db, callback) {
       db.close(callback)
     }
 

--- a/test/benchmarks/engines/levelup-nosnappy.js
+++ b/test/benchmarks/engines/levelup-nosnappy.js
@@ -3,8 +3,7 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup   = require('../../../')
-  , leveldown = require('leveldown')
+var levelup = require('../../../')
 
   , createDb = function (location, callback) {
       levelup(location, { compression: false }, function (err, db) {

--- a/test/benchmarks/engines/levelup.js
+++ b/test/benchmarks/engines/levelup.js
@@ -3,15 +3,16 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../../../')
+var levelup   = require('../../../')
+  , leveldown = require('leveldown')
 
-  , createDb = function (location, callback) {
-      levelup(location, function (err, db) {
+  , createDb  = function (location, callback) {
+      levelup(leveldown(location), function (err, db) {
         setTimeout(callback.bind(null, err, db), 50)
       })
     }
 
-  , closeDb = function (db, callback) {
+  , closeDb  = function (db, callback) {
       db.close(callback)
     }
 

--- a/test/benchmarks/package.json
+++ b/test/benchmarks/package.json
@@ -8,7 +8,7 @@
     "async": "~0.1.22",
     "benchmark": "~1.0.0",
     "colors": "~0.6.0-1",
-    "leveldown": "^0.10.4",
+    "leveldown": "^1.1.0",
     "levelup": "*",
     "rimraf": "~2.0.2",
     "sqlite3": "*"

--- a/test/common.js
+++ b/test/common.js
@@ -72,12 +72,10 @@ module.exports.openTestDatabase = function () {
     , callback = typeof arguments[0] == 'function' ? arguments[0] : arguments[1]
     , location = typeof arguments[0] == 'string' ? arguments[0] : module.exports.nextLocation()
 
-  options.db = leveldown
-
   rimraf(location, function (err) {
     refute(err)
     this.cleanupDirs.push(location)
-    levelup(location, options, function (err, db) {
+    levelup(leveldown(location), options, function (err, db) {
       refute(err)
       if (!err) {
         this.closeableDatabases.push(db)

--- a/test/deferred-open-test.js
+++ b/test/deferred-open-test.js
@@ -19,12 +19,11 @@ buster.testCase('Deferred open()', {
   , 'put() and get() on pre-opened database': function (done) {
       var location = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db       = levelup(location, { valueEncoding: 'utf8', db: leveldown })
+        , db       = levelup(leveldown(location), { valueEncoding: 'utf8' })
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
       assert.isObject(db)
-      assert.equals(db.location, location)
 
       async.parallel([
       // 2) insert 3 values with put(), these should be deferred until the database is actually open
@@ -62,12 +61,11 @@ buster.testCase('Deferred open()', {
   , 'batch() on pre-opened database': function (done) {
       var location = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db       = levelup(location, { valueEncoding: 'utf8', db: leveldown })
+        , db       = levelup(leveldown(location), { valueEncoding: 'utf8' })
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
       assert.isObject(db)
-      assert.equals(db.location, location)
 
       // 2) insert 3 values with batch(), these should be deferred until the database is actually open
       db.batch([
@@ -105,12 +103,11 @@ buster.testCase('Deferred open()', {
   , 'chained batch() on pre-opened database': function (done) {
       var location = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db       = levelup(location, { valueEncoding: 'utf8', db: leveldown })
+        , db       = levelup(leveldown(location), { valueEncoding: 'utf8' })
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
       assert.isObject(db)
-      assert.equals(db.location, location)
 
       // 2) insert 3 values with batch(), these should be deferred until the database is actually open
       db.batch()
@@ -150,18 +147,20 @@ buster.testCase('Deferred open()', {
         'setUp': common.readStreamSetUp
 
       , 'simple ReadStream': function (done) {
-          this.openTestDatabase(function (db) {
-            var location = db.location
-            db.batch(this.sourceData.slice(), function (err) {
-              refute(err)
-              db.close(function (err) {
-                refute(err, 'no error')
-                db = levelup(location, { db: leveldown })
-                var rs = db.createReadStream()
-                rs.on('data' , this.dataSpy)
-                rs.on('end'  , this.endSpy)
-                rs.on('close', this.verify.bind(this, rs, done))
-              }.bind(this))
+          var location = common.nextLocation()
+            , db       = levelup(leveldown(location))
+          this.cleanupDirs.push(location)
+
+          db.batch(this.sourceData.slice(), function (err) {
+            refute(err)
+            db.close(function (err) {
+              refute(err, 'no error')
+              db = levelup(leveldown(location))
+              this.closeableDatabases.push(db)
+              var rs = db.createReadStream()
+              rs.on('data' , this.dataSpy)
+              rs.on('end'  , this.endSpy)
+              rs.on('close', this.verify.bind(this, rs, done))
             }.bind(this))
           }.bind(this))
         }
@@ -170,7 +169,7 @@ buster.testCase('Deferred open()', {
   , 'maxListeners warning': function (done) {
       var location   = common.nextLocation()
       // 1) open database without callback, opens in worker thread
-        , db         = levelup(location, { valueEncoding: 'utf8', db: leveldown })
+        , db         = levelup(leveldown(location), { valueEncoding: 'utf8' })
         , stderrMock = this.mock(console)
 
       this.closeableDatabases.push(db)

--- a/test/encoding-test.js
+++ b/test/encoding-test.js
@@ -16,52 +16,46 @@ buster.testCase('Encoding', {
   , 'tearDown': common.commonTearDown
 
   , 'test safe decode in get()': function (done) {
-      this.openTestDatabase(
-          { valueEncoding: 'utf8' }
-        , function (db) {
-            db.put('foo', 'this {} is [] not : json', function (err) {
-              refute(err)
-              db.close(function (err) {
-                refute(err)
-                db = levelup(db.location, { valueEncoding: 'json', db: leveldown })
-                db.get('foo', function (err, value) {
-                  assert(err)
-                  assert.equals('EncodingError', err.name)
-                  refute(value)
-                  db.close(done)
-                })
-              })
-            })
-          }
-      )
+      var location = common.nextLocation()
+        , db       = levelup(leveldown(location), { valueEncoding: 'utf8' })
+      db.put('foo', 'this {} is [] not : json', function (err) {
+        refute(err)
+        db.close(function (err) {
+          refute(err)
+          db = levelup(leveldown(location), { valueEncoding: 'json' })
+          db.get('foo', function (err, value) {
+            assert(err)
+            assert.equals('EncodingError', err.name)
+            refute(value)
+            db.close(done)
+          })
+        })
+      })
     }
 
   , 'test safe decode in readStream()': function (done) {
-      this.openTestDatabase(
-          { valueEncoding: 'utf8' }
-        , function (db) {
-            db.put('foo', 'this {} is [] not : json', function (err) {
-              refute(err)
-              db.close(function (err) {
-                refute(err)
+      var location = common.nextLocation()
+        , db       = levelup(leveldown(location), { valueEncoding: 'utf8' })
+      db.put('foo', 'this {} is [] not : json', function (err) {
+        refute(err)
+        db.close(function (err) {
+          refute(err)
 
-                var dataSpy  = this.spy()
-                  , errorSpy = this.spy()
+          var dataSpy  = this.spy()
+            , errorSpy = this.spy()
 
-                db = levelup(db.location, { valueEncoding: 'json', db: leveldown })
-                db.readStream()
-                  .on('data', dataSpy)
-                  .on('error', errorSpy)
-                  .on('close', function () {
-                    assert.equals(dataSpy.callCount, 0, 'no data')
-                    assert.equals(errorSpy.callCount, 1, 'error emitted')
-                    assert.equals('EncodingError', errorSpy.getCall(0).args[0].name)
-                    db.close(done)
-                  })
-              }.bind(this))
-            }.bind(this))
-          }.bind(this)
-      )
+          db = levelup(leveldown(location), { valueEncoding: 'json' })
+          db.readStream()
+            .on('data', dataSpy)
+            .on('error', errorSpy)
+            .on('close', function () {
+              assert.equals(dataSpy.callCount, 0, 'no data')
+              assert.equals(errorSpy.callCount, 1, 'error emitted')
+              assert.equals('EncodingError', errorSpy.getCall(0).args[0].name)
+              db.close(done)
+            })
+        }.bind(this))
+      }.bind(this))
     }
 
   , 'test encoding = valueEncoding': function (done) {

--- a/test/idempotent-test.js
+++ b/test/idempotent-test.js
@@ -38,8 +38,7 @@ buster.testCase('Idempotent open & close', {
       this.cleanupDirs.push(location)
 
       db = levelup(
-          location
-        , { db: leveldown }
+          leveldown(location)
         , function () {
             assert.equals(n++, 0, 'callback should fire only once')
             if (n && m)

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -26,7 +26,7 @@ buster.testCase('Init & open()', {
 
   , 'default options': function (done) {
       var location = common.nextLocation()
-      levelup(location, { db: leveldown }, function (err, db) {
+      levelup(leveldown(location), function (err, db) {
         refute(err, 'no error')
         assert.isTrue(db.isOpen())
         this.closeableDatabases.push(db)
@@ -36,16 +36,11 @@ buster.testCase('Init & open()', {
 
           assert.isFalse(db.isOpen())
 
-          levelup(location, { db: leveldown }, function (err, db) { // no options object
+          levelup(leveldown(location), function (err, db) { // no options object
             refute(err)
             assert.isObject(db)
             assert.equals(db.options.keyEncoding, 'utf8')
             assert.equals(db.options.valueEncoding, 'utf8')
-            assert.equals(db.location, location)
-
-            // read-only properties
-            db.location = 'foo'
-            assert.equals(db.location, location)
 
             done()
           }.bind(this))
@@ -56,8 +51,8 @@ buster.testCase('Init & open()', {
   , 'basic options': function (done) {
       var location = common.nextLocation()
       levelup(
-          location
-        , { valueEncoding: 'binary', db: leveldown }
+          leveldown(location)
+        , { valueEncoding: 'binary' }
         , function (err, db) {
             refute(err)
 
@@ -66,12 +61,6 @@ buster.testCase('Init & open()', {
             assert.isObject(db)
             assert.equals(db.options.keyEncoding, 'utf8')
             assert.equals(db.options.valueEncoding, 'binary')
-            assert.equals(db.location, location)
-
-
-            // read-only properties
-            db.location = 'bar'
-            assert.equals(db.location, location)
 
             done()
           }.bind(this)
@@ -81,8 +70,8 @@ buster.testCase('Init & open()', {
   , 'options with encoding': function (done) {
       var location = common.nextLocation()
       levelup(
-          location
-        , { keyEncoding: 'ascii', valueEncoding: 'json', db: leveldown }
+          leveldown(location)
+        , { keyEncoding: 'ascii', valueEncoding: 'json' }
         , function (err, db) {
             refute(err)
 
@@ -91,12 +80,6 @@ buster.testCase('Init & open()', {
             assert.isObject(db)
             assert.equals(db.options.keyEncoding, 'ascii')
             assert.equals(db.options.valueEncoding, 'json')
-            assert.equals(db.location, location)
-
-
-            // read-only properties
-            db.location = 'bar'
-            assert.equals(db.location, location)
 
             done()
           }.bind(this)
@@ -105,48 +88,15 @@ buster.testCase('Init & open()', {
 
   , 'without callback': function (done) {
       var location = common.nextLocation()
-        , db = levelup(location, { db: leveldown })
+        , db = levelup(leveldown(location))
 
       this.closeableDatabases.push(db)
       this.cleanupDirs.push(location)
       assert.isObject(db)
-      assert.equals(db.location, location)
 
       db.on("ready", function () {
         assert.isTrue(db.isOpen())
         done()
-      })
-    }
-
-  , 'constructor with options argument uses factory': function (done) {
-      var db = levelup({ db: MemDOWN })
-      assert.isNull(db.location, 'location property is null')
-      db.on('open', function () {
-        assert(db.db instanceof MemDOWN, 'using a memdown backend')
-        assert.same(db.db.location, '', 'db location property is ""')
-        db.put('foo', 'bar', function (err) {
-          refute(err, 'no error')
-          db.get('foo', function (err, value) {
-            assert.equals(value, 'bar', 'correct value')
-            done()
-          })
-        })
-      })
-    }
-
-  , 'constructor with only function argument uses factory': function (done) {
-      var db = levelup(MemDOWN)
-      assert.isNull(db.location, 'location property is null')
-      db.on('open', function () {
-        assert(db.db instanceof MemDOWN, 'using a memdown backend')
-        assert.same(db.db.location, '', 'db location property is ""')
-        db.put('foo', 'bar', function (err) {
-          refute(err, 'no error')
-          db.get('foo', function (err, value) {
-            assert.equals(value, 'bar', 'correct value')
-            done()
-          })
-        })
       })
     }
 })

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -99,4 +99,18 @@ buster.testCase('Init & open()', {
         done()
       })
     }
+
+  , 'validate leveldown': function (done) {
+      var down = leveldown(common.nextLocation())
+      Object.defineProperty(down, 'status', {
+        get: function () { return null },
+        set: function () {}
+      })
+      try {
+        levelup(down)
+      } catch (err) {
+        return done()
+      }
+      throw new Error('did not throw')
+    }
 })

--- a/test/inject-encoding-test.js
+++ b/test/inject-encoding-test.js
@@ -20,14 +20,13 @@ buster.testCase('JSON API', {
           var location = common.nextLocation()
           this.cleanupDirs.push(location)
           console.log(location)
-          levelup(location, {
+          levelup(leveldown(location), {
             valueEncoding: {
               encode: msgpack.encode,
               decode: msgpack.decode,
               buffer: true,
               type: 'msgpack'
-            },
-            db: leveldown
+            }
           }, function (err, db) {
             refute(err)
             if (err) return

--- a/test/json-test.js
+++ b/test/json-test.js
@@ -18,7 +18,7 @@ buster.testCase('JSON API', {
         this.runTest = function (testData, assertType, done) {
           var location = common.nextLocation()
           this.cleanupDirs.push(location)
-          levelup(location, { valueEncoding: {encode: JSON.stringify, decode: JSON.parse }, db: leveldown }, function (err, db) {
+          levelup(leveldown(location), { valueEncoding: {encode: JSON.stringify, decode: JSON.parse } }, function (err, db) {
             refute(err)
             if (err) return
 

--- a/test/leveldown-substitution-test.js
+++ b/test/leveldown-substitution-test.js
@@ -14,8 +14,7 @@ require('./common')
 buster.testCase('LevelDOWN Substitution', {
     'test substitution of LevelDOWN with MemDOWN': function (done) {
       var md       = new MemDOWN('foo')
-        , db       =
-            levelup('/somewhere/not/writable/booya!', { db: function () { return md } })
+        , db       = levelup(md)
         , entries  = []
         , expected = [
               { key: 'a', value: 'A' }

--- a/test/null-and-undefined-test.js
+++ b/test/null-and-undefined-test.js
@@ -18,7 +18,7 @@ buster.testCase('null & undefined keys & values', {
 
   , 'null and undefined': {
         'setUp': function (done) {
-          levelup(this.cleanupDirs[0] = common.nextLocation(), { db: leveldown }, function (err, db) {
+          levelup(leveldown(this.cleanupDirs[0] = common.nextLocation()), function (err, db) {
             refute(err) // sanity
             this.closeableDatabases.push(db)
             assert.isTrue(db.isOpen())

--- a/test/open-patchsafe-test.js
+++ b/test/open-patchsafe-test.js
@@ -15,12 +15,11 @@ function test(fun) {
   return function (done) {
     var location = common.nextLocation()
     // 1) open database without callback, opens in worker thread
-      , db       = levelup(location, { valueEncoding: 'utf8', db: leveldown })
+      , db       = levelup(leveldown(location), { valueEncoding: 'utf8' })
 
     this.closeableDatabases.push(db)
     this.cleanupDirs.push(location)
     assert.isObject(db)
-    assert.equals(db.location, location)
 
     fun(db, done)
     // we should still be in a state of limbo down here, not opened or closed, but 'new'


### PR DESCRIPTION
this changes the api from

```js
var db = levelup(location, { db: leveldown })
```

to

```js
var db = levelup(leveldown(location))
```

this is for v2