### PR TITLE
improve error message when trying to require leveldown

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -4,8 +4,9 @@
  * <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var extend        = require('xtend')
-  , LevelUPError  = require('level-errors').LevelUPError
+var extend         = require('xtend')
+  , LevelUPError   = require('level-errors').LevelUPError
+  , format         = require('util').format
   , defaultOptions = {
         createIfMissing : true
       , errorIfExists   : false
@@ -28,14 +29,13 @@ function getLevelDOWN () {
   if (leveldown)
     return leveldown
 
-  var requiredVersion       = require('../package.json').devDependencies.leveldown
-    , missingLevelDOWNError = 'Could not locate LevelDOWN, try `npm install leveldown`'
+  var requiredVersion  = require('../package.json').devDependencies.leveldown
     , leveldownVersion
 
   try {
     leveldownVersion = require('leveldown/package').version
   } catch (e) {
-    throw new LevelUPError(missingLevelDOWNError)
+    throw requireError(e)
   }
 
   if (!require('semver').satisfies(leveldownVersion, requiredVersion)) {
@@ -51,8 +51,13 @@ function getLevelDOWN () {
   try {
     return leveldown = require('leveldown')
   } catch (e) {
-    throw new LevelUPError(missingLevelDOWNError)
+    throw requireError(e)
   }
+}
+
+function requireError (e) {
+  var template = 'Failed to require LevelDOWN (%s). Try `npm install leveldown` if it\'s missing'
+  return new LevelUPError(format(template, e.message))
 }
 
 function dispatchError (db, error, callback) {


### PR DESCRIPTION
I'm trying to iron out some problems we get when trying to require `leveldown` (see https://github.com/Level/leveldown/issues/190).

Currently we give the advice to try and `npm install leveldown` if requiring it doesn't work. This error message isn't very helpful when you before receiving the error actually did install it.

This PR uses the error message we get in `try/catch` so we can get more information (e.g. the current ABI version and the expected ABI version).