### PR TITLE
Track and expose lengths of chained batch operations queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ This method may `throw` a `WriteError` if there is a problem with your delete.
 
 Clear all queued operations on the current batch, any previous operations will be discarded.
 
+<b><code>batch.length</code></b>
+
+The number of queued operations on the current batch.
+
 <b><code>batch.write([callback])</code></b>
 
 Commit the queued operations for this batch. All operations not *cleared* will be written to the database atomically, that is, they will either all succeed or fail with no partial commits. The optional `callback` will be called when the operation has completed with an *error* argument if an error has occurred; if no `callback` is supplied and an error occurs then this method will `throw` a `WriteError`.

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -15,6 +15,7 @@ function Batch (levelup, codec) {
   this._codec = codec
   this.batch = levelup.db.batch()
   this.ops = []
+  this.length = 0
 }
 
 Batch.prototype.put = function (key_, value_, options) {
@@ -29,6 +30,7 @@ Batch.prototype.put = function (key_, value_, options) {
     throw new WriteError(e)
   }
   this.ops.push({ type : 'put', key : key, value : value })
+  this.length++
 
   return this
 }
@@ -44,6 +46,7 @@ Batch.prototype.del = function (key_, options) {
     throw new WriteError(err)
   }
   this.ops.push({ type : 'del', key : key })
+  this.length++
 
   return this
 }
@@ -56,6 +59,7 @@ Batch.prototype.clear = function () {
   }
 
   this.ops = []
+  this.length = 0
   return this
 }
 

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -164,6 +164,25 @@ buster.testCase('batch()', {
       })
     }
 
+  , 'batch() exposes ops queue length': function (done) {
+      this.openTestDatabase(function (db) {
+        var batch = db.batch()
+          .put('one', '1')
+          .del('two')
+          .put('three', '3')
+        assert.equals(batch.length, 3)
+        batch.clear()
+        assert.equals(batch.length, 0)
+        batch
+          .del('1')
+          .put('2', 'two')
+          .put('3', 'three')
+          .del('3')
+        assert.equals(batch.length, 4)
+        done()
+      })
+    }
+
   , 'batch() with can manipulate data from put()': function (done) {
       // checks encoding and whatnot
       this.openTestDatabase(function (db) {


### PR DESCRIPTION
Following up on #371 with a patch, [per request](https://github.com/Level/levelup/issues/371#issuecomment-146499907).

This PR tracks and exposes the length of the operations queues of chained batch objects:

```javascript
var assert = require('assert')
var levelup = require('levelup')
var memdown = require('memdown')

var level = levelup({ db: memdown })
var batch = level.batch().put('a', '1').put('b', '2').del('c')

// New
assert.equal(batch.length, 3)

batch.put('d', '4')

// New
assert.equal(batch.length, 4)
```

@juliangruber, you mentioned using a getter, but I don't think you'd decided. Please let me know if I should rewrite with `defineProperty`.

Many thanks to all involved!