### PR TITLE
bump semver for nsp fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
   - "0.12"
   - "1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,23 +2,12 @@ language: node_js
 node_js:
   - "0.8"
   - "0.10"
-branches:
-  only:
-    - master
-notifications:
-  email:
-    - r@va.gg
-    - john@chesl.es
-    - raynos2@gmail.com
-    - dominic.tarr@gmail.com
-    - max@maxogden.com
-    - lars.magnus.skog@gmail.com
-    - david.bjorklund@gmail.com
-    - julian@juliangruber.com
-    - paolo@async.ly
-    - anton.whalley@nearform.com
-    - matteo.collina@gmail.com
-    - pedro.teixeira@gmail.com
-    - mail@substack.net
+  - "0.12"
+  - "1.0"
+  - "1.8"
+  - "2"
+  - "3"
+  - "4"
+  - "5"
 script: npm run-script alltests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,17 @@
+sudo: false
+
 language: node_js
+
+env:
+  - CXX=g++-4.8
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+
 node_js:
   - "0.10"
   - "0.12"
@@ -8,5 +21,6 @@ node_js:
   - "3"
   - "4"
   - "5"
+
 script: npm run-script alltests
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "referee": "*",
     "rimraf": "*",
     "slow-stream": ">=0.0.4",
-    "tap": "*",
+    "tap": "2.x.x",
     "tar": "*"
   },
   "browser": {

--- a/package.json
+++ b/package.json
@@ -38,26 +38,26 @@
     "errno": "~0.1.1",
     "prr": "~0.0.0",
     "readable-stream": "~1.0.26",
-    "semver": "~2.3.1",
+    "semver": "~5.1.0",
     "xtend": "~3.0.0"
   },
   "devDependencies": {
-    "leveldown": "~0.10.0",
+    "async": "*",
+    "boganipsum": "*",
     "bustermove": "*",
-    "tap": "*",
+    "delayed": "*",
+    "du": "*",
+    "fstream": "*",
+    "leveldown": "~0.10.0",
+    "memdown": "^0.11.0",
+    "mkfiletree": "*",
+    "msgpack-js": "*",
+    "readfiletree": "*",
     "referee": "*",
     "rimraf": "*",
-    "async": "*",
-    "fstream": "*",
-    "tar": "*",
-    "mkfiletree": "*",
-    "readfiletree": "*",
     "slow-stream": ">=0.0.4",
-    "delayed": "*",
-    "boganipsum": "*",
-    "du": "*",
-    "memdown": "*",
-    "msgpack-js": "*"
+    "tap": "*",
+    "tar": "*"
   },
   "browser": {
     "leveldown": false,
@@ -65,7 +65,7 @@
     "semver": false
   },
   "scripts": {
-    "test": "tap test/*-test.js --stderr",
+    "test": "tap test/*-test.js",
     "functionaltests": "node ./test/functional/fstream-test.js && node ./test/functional/binary-data-test.js && node ./test/functional/compat-test.js",
     "alltests": "npm test && npm run-script functionaltests"
   },


### PR DESCRIPTION
`nsp` reports a problem becase `levelup` is using a version of `semver` with a known vulnerability, see https://nodesecurity.io/advisories/31

![levelup-semver-nsp](https://cloud.githubusercontent.com/assets/308049/12512359/3f117cc2-c118-11e5-9b9d-16f6e921c3f7.png)

![levelup-nsp-fix](https://cloud.githubusercontent.com/assets/308049/12512370/49aecf72-c118-11e5-9600-aba655f5c1af.png)

I originally started looking at updating `level-sublevel` but there were just too many changes to be made *just* to be able to update `semver`, so I think we should release `0.19.1` instead, and then `level-sublevel` can at least use that version of `levelup` to start with.