### PR TITLE
Let encoding-down handle encodings

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -10,19 +10,15 @@ var util          = require('./util')
   , getOptions    = util.getOptions
   , dispatchError = util.dispatchError
 
-function Batch (levelup, codec) {
+function Batch (levelup) {
   this._levelup = levelup
-  this._codec = codec
   this.batch = levelup.db.batch()
   this.ops = []
   this.length = 0
 }
 
-Batch.prototype.put = function (key_, value_, options) {
+Batch.prototype.put = function (key, value, options) {
   options = getOptions(options)
-
-  var key   = this._codec.encodeKey(key_, options)
-    , value = this._codec.encodeValue(value_, options)
 
   try {
     this.batch.put(key, value)
@@ -35,10 +31,8 @@ Batch.prototype.put = function (key_, value_, options) {
   return this
 }
 
-Batch.prototype.del = function (key_, options) {
+Batch.prototype.del = function (key, options) {
   options = getOptions(options)
-
-  var key = this._codec.encodeKey(key_, options)
 
   try {
     this.batch.del(key)

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -10,6 +10,7 @@ var EventEmitter        = require('events').EventEmitter
   , extend              = require('xtend')
   , prr                 = require('prr')
   , DeferredLevelDOWN   = require('deferred-leveldown')
+  , EncodingDOWN        = require('encoding-down')
   , IteratorStream      = require('level-iterator-stream')
 
   , errors              = require('level-errors')
@@ -22,7 +23,6 @@ var EventEmitter        = require('events').EventEmitter
 
   , util                = require('./util')
   , Batch               = require('./batch')
-  , Codec               = require('level-codec')
 
   , getOptions          = util.getOptions
   , defaultOptions      = util.defaultOptions
@@ -79,7 +79,6 @@ function LevelUP (location, options, callback) {
 
   options      = getOptions(options)
   this.options = extend(defaultOptions, options)
-  this._codec = new Codec(this.options)
   this._status = 'new'
   // set this.location as enumerable but not configurable or writable
   prr(this, 'location', location, 'e')
@@ -113,6 +112,7 @@ LevelUP.prototype.open = function (callback) {
   this.db      = new DeferredLevelDOWN(this.location)
   dbFactory    = this.options.db || getLevelDOWN()
   db           = dbFactory(this.location)
+  db           = EncodingDOWN(db, this.options)
 
   db.open(this.options, function (err) {
     if (err) {
@@ -193,118 +193,99 @@ function readError (db, message, callback) {
 }
 
 
-LevelUP.prototype.get = function (key_, options, callback) {
+LevelUP.prototype.get = function (key, options, callback) {
   var self = this
-    , key
 
   callback = getCallback(options, callback)
 
   if (maybeError(this, options, callback))
     return
 
-  if (key_ === null || key_ === undefined || 'function' !== typeof callback)
+  if (key === null || key === undefined || 'function' !== typeof callback)
     return readError(this
       , 'get() requires key and callback arguments', callback)
 
   options = util.getOptions(options)
-  key = this._codec.encodeKey(key_, options)
-
-  options.asBuffer = this._codec.valueAsBuffer(options)
 
   this.db.get(key, options, function (err, value) {
     if (err) {
       if ((/notfound/i).test(err) || err.notFound) {
         err = new NotFoundError(
-            'Key not found in database [' + key_ + ']', err)
-      } else {
+            'Key not found in database [' + key + ']', err)
+      } else if (err.name !== 'EncodingError') {
         err = new ReadError(err)
       }
       return dispatchError(self, err, callback)
     }
-    if (callback) {
-      try {
-        value = self._codec.decodeValue(value, options)
-      } catch (e) {
-        return callback(new EncodingError(e))
-      }
-      callback(null, value)
-    }
+    if (callback) callback(null, value)
   })
 }
 
-LevelUP.prototype.put = function (key_, value_, options, callback) {
+LevelUP.prototype.put = function (key, value, options, callback) {
   var self = this
-    , key
-    , value
 
   callback = getCallback(options, callback)
 
-  if (key_ === null || key_ === undefined)
+  if (key === null || key === undefined)
     return writeError(this, 'put() requires a key argument', callback)
 
   if (maybeError(this, options, callback))
     return
 
   options = getOptions(options)
-  key     = this._codec.encodeKey(key_, options)
-  value   = this._codec.encodeValue(value_, options)
 
   this.db.put(key, value, options, function (err) {
     if (err) {
       return dispatchError(self, new WriteError(err), callback)
     } else {
-      self.emit('put', key_, value_)
+      self.emit('put', key, value)
       if (callback)
         callback()
     }
   })
 }
 
-LevelUP.prototype.del = function (key_, options, callback) {
+LevelUP.prototype.del = function (key, options, callback) {
   var self = this
-    , key
 
   callback = getCallback(options, callback)
 
-  if (key_ === null || key_ === undefined)
+  if (key === null || key === undefined)
     return writeError(this, 'del() requires a key argument', callback)
 
   if (maybeError(this, options, callback))
     return
 
   options = getOptions(options)
-  key     = this._codec.encodeKey(key_, options)
 
   this.db.del(key, options, function (err) {
     if (err) {
       return dispatchError(self, new WriteError(err), callback)
     } else {
-      self.emit('del', key_)
+      self.emit('del', key)
       if (callback)
         callback()
     }
   })
 }
 
-LevelUP.prototype.batch = function (arr_, options, callback) {
+LevelUP.prototype.batch = function (arr, options, callback) {
   var self = this
     , keyEnc
     , valueEnc
-    , arr
 
   if (!arguments.length)
-    return new Batch(this, this._codec)
+    return new Batch(this)
 
   callback = getCallback(options, callback)
 
-  if (!Array.isArray(arr_))
+  if (!Array.isArray(arr))
     return writeError(this, 'batch() requires an array argument', callback)
 
   if (maybeError(this, options, callback))
     return
 
   options  = getOptions(options)
-  arr      = self._codec.encodeBatch(arr_, options)
   arr      = arr.map(function (op) {
     if (!op.type && op.key !== undefined && op.value !== undefined)
       op.type = 'put'
@@ -315,28 +296,23 @@ LevelUP.prototype.batch = function (arr_, options, callback) {
     if (err) {
       return dispatchError(self, new WriteError(err), callback)
     } else {
-      self.emit('batch', arr_)
+      self.emit('batch', arr)
       if (callback)
         callback()
     }
   })
 }
 
-LevelUP.prototype.approximateSize = deprecate(function (start_, end_, options, callback) {   
+LevelUP.prototype.approximateSize = deprecate(function (start, end, options, callback) {   
   var self = this    
-    , start    
-    , end    
    
   callback = getCallback(options, callback)    
    
   options = getOptions(options)    
    
-  if (start_ === null || start_ === undefined    
-        || end_ === null || end_ === undefined || 'function' !== typeof callback)    
+  if (start === null || start === undefined    
+        || end === null || end === undefined || 'function' !== typeof callback)    
     return readError(this, 'approximateSize() requires start, end and callback arguments', callback)   
-   
-  start = this._codec.encodeKey(start_, options)   
-  end   = this._codec.encodeKey(end_, options)   
    
   this.db.approximateSize(start, end, function (err, size) {   
     if (err) {   
@@ -354,16 +330,10 @@ LevelUP.prototype.createReadStream = function (options) {
   options.keyEncoding   = options.keyEncoding
   options.valueEncoding = options.valueEncoding
 
-  options = this._codec.encodeLtgt(options);
-  options.keyAsBuffer   = this._codec.keyAsBuffer(options)
-  options.valueAsBuffer = this._codec.valueAsBuffer(options)
-
   if ('number' !== typeof options.limit)
     options.limit = -1
 
-  return new IteratorStream(this.db.iterator(options), extend(options, {
-    decoder: this._codec.createStreamDecoder(options)
-  }))
+  return new IteratorStream(this.db.iterator(options), options)
 }
 
 LevelUP.prototype.keyStream =

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "main": "lib/levelup.js",
   "dependencies": {
     "deferred-leveldown": "~1.2.1",
-    "level-codec": "~6.1.0",
+    "encoding-down": "^2.1.4",
     "level-errors": "~1.0.3",
     "level-iterator-stream": "~1.3.0",
     "prr": "~1.0.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "main": "lib/levelup.js",
   "dependencies": {
     "deferred-leveldown": "~1.2.1",
-    "encoding-down": "^2.1.4",
+    "encoding-down": "~2.1.4",
     "level-errors": "~1.0.3",
     "level-iterator-stream": "~1.3.0",
     "prr": "~1.0.1",

--- a/test/benchmarks/package.json
+++ b/test/benchmarks/package.json
@@ -8,7 +8,7 @@
     "async": "~0.1.22",
     "benchmark": "~1.0.0",
     "colors": "~0.6.0-1",
-    "leveldown": "^1.5.3",
+    "leveldown": "~1.5.3",
     "levelup": "*",
     "rimraf": "~2.0.2",
     "sqlite3": "*"

--- a/test/benchmarks/package.json
+++ b/test/benchmarks/package.json
@@ -8,7 +8,7 @@
     "async": "~0.1.22",
     "benchmark": "~1.0.0",
     "colors": "~0.6.0-1",
-    "leveldown": "^0.10.4",
+    "leveldown": "^1.5.3",
     "levelup": "*",
     "rimraf": "~2.0.2",
     "sqlite3": "*"

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -22,7 +22,7 @@ buster.testCase('Binary API', {
     }
 
   , 'tearDown': common.commonTearDown
-/*
+
   , 'sanity check on test data': function (done) {
       assert(Buffer.isBuffer(this.testData))
       common.checkBinaryTestData(this.testData, done)
@@ -40,7 +40,7 @@ buster.testCase('Binary API', {
         })
       }.bind(this))
     }
-*/
+
   , 'test put() and get() with binary value {valueEncoding:binary} on createDatabase()': function (done) {
       this.openTestDatabase({ createIfMissing: true, errorIfExists: true, valueEncoding: 'binary' }, function (db) {
         db.put('binarydata', this.testData, function (err) {
@@ -53,7 +53,7 @@ buster.testCase('Binary API', {
         })
       }.bind(this))
     }
-/*
+
   , 'test put() and get() with binary key {valueEncoding:binary}': function (done) {
       this.openTestDatabase(function (db) {
         db.put(this.testData, 'binarydata', { valueEncoding: 'binary' }, function (err) {
@@ -167,5 +167,4 @@ buster.testCase('Binary API', {
         )
       }.bind(this))
     }
-  */
 })

--- a/test/binary-test.js
+++ b/test/binary-test.js
@@ -22,7 +22,7 @@ buster.testCase('Binary API', {
     }
 
   , 'tearDown': common.commonTearDown
-
+/*
   , 'sanity check on test data': function (done) {
       assert(Buffer.isBuffer(this.testData))
       common.checkBinaryTestData(this.testData, done)
@@ -40,7 +40,7 @@ buster.testCase('Binary API', {
         })
       }.bind(this))
     }
-
+*/
   , 'test put() and get() with binary value {valueEncoding:binary} on createDatabase()': function (done) {
       this.openTestDatabase({ createIfMissing: true, errorIfExists: true, valueEncoding: 'binary' }, function (db) {
         db.put('binarydata', this.testData, function (err) {
@@ -53,7 +53,7 @@ buster.testCase('Binary API', {
         })
       }.bind(this))
     }
-
+/*
   , 'test put() and get() with binary key {valueEncoding:binary}': function (done) {
       this.openTestDatabase(function (db) {
         db.put(this.testData, 'binarydata', { valueEncoding: 'binary' }, function (err) {
@@ -167,4 +167,5 @@ buster.testCase('Binary API', {
         )
       }.bind(this))
     }
+  */
 })

--- a/test/encoding-test.js
+++ b/test/encoding-test.js
@@ -34,6 +34,7 @@ buster.testCase('Encoding', {
           }
       )
     }
+    
 
   , 'test safe decode in readStream()': function (done) {
       this.openTestDatabase(
@@ -43,6 +44,7 @@ buster.testCase('Encoding', {
               refute(err)
               db.close(function (err) {
                 refute(err)
+                  console.log('db closed')
 
                 var dataSpy  = this.spy()
                   , errorSpy = this.spy()
@@ -50,11 +52,9 @@ buster.testCase('Encoding', {
                 db = levelup(db.location, { createIfMissing: false, errorIfExists: false, valueEncoding: 'json' })
                 db.readStream()
                   .on('data', dataSpy)
-                  .on('error', errorSpy)
-                  .on('close', function () {
+                  .on('error', function (err) {
                     assert.equals(dataSpy.callCount, 0, 'no data')
-                    assert.equals(errorSpy.callCount, 1, 'error emitted')
-                    assert.equals('EncodingError', errorSpy.getCall(0).args[0].name)
+                    assert.equals('EncodingError', err.name)
                     db.close(done)
                   })
               }.bind(this))
@@ -78,6 +78,7 @@ buster.testCase('Encoding', {
         })
       })
     }
+    
   , 'test batch op encoding': function (done) {
       this.openTestDatabase({ valueEncoding: 'json' }, function (db) {
         db.batch([
@@ -112,4 +113,5 @@ buster.testCase('Encoding', {
         })
       })
     }
+    
 })

--- a/test/encoding-test.js
+++ b/test/encoding-test.js
@@ -44,7 +44,6 @@ buster.testCase('Encoding', {
               refute(err)
               db.close(function (err) {
                 refute(err)
-                  console.log('db closed')
 
                 var dataSpy  = this.spy()
                   , errorSpy = this.spy()
@@ -78,7 +77,6 @@ buster.testCase('Encoding', {
         })
       })
     }
-    
   , 'test batch op encoding': function (done) {
       this.openTestDatabase({ valueEncoding: 'json' }, function (db) {
         db.batch([
@@ -113,5 +111,4 @@ buster.testCase('Encoding', {
         })
       })
     }
-    
 })

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -187,7 +187,6 @@ buster.testCase('Init & open()', {
       var db = levelup({ db: MemDOWN })
       assert.isNull(db.location, 'location property is null')
       db.on('open', function () {
-        assert(db.db instanceof MemDOWN, 'using a memdown backend')
         assert.same(db.db.location, '', 'db location property is ""')
         db.put('foo', 'bar', function (err) {
           refute(err, 'no error')
@@ -203,7 +202,6 @@ buster.testCase('Init & open()', {
       var db = levelup(MemDOWN)
       assert.isNull(db.location, 'location property is null')
       db.on('open', function () {
-        assert(db.db instanceof MemDOWN, 'using a memdown backend')
         assert.same(db.db.location, '', 'db location property is ""')
         db.put('foo', 'bar', function (err) {
           refute(err, 'no error')


### PR DESCRIPTION
Without a notable performance degradation, this gets rid of a lot of encoding code.

Before we merge this, we should make sure

- [ ] non of the dependencies relies on `db.db` being exactly their leveldown instance
- [ ] `encoding-down` has a good test suite