### PR TITLE
Pull LevelDOWN loader out to non-Browserified module

### DIFF
--- a/lib/leveldown.js
+++ b/lib/leveldown.js
@@ -1,0 +1,40 @@
+var LevelUPError   = require('level-errors').LevelUPError
+  , format         = require('util').format
+  , leveldown
+
+function getLevelDOWN () {
+  if (leveldown)
+    return leveldown
+
+  var requiredVersion  = require('../package.json').devDependencies.leveldown
+    , leveldownVersion
+
+  try {
+    leveldownVersion = require('leveldown/package.json').version
+  } catch (e) {
+    throw requireError(e)
+  }
+
+  if (!require('semver').satisfies(leveldownVersion, requiredVersion)) {
+    throw new LevelUPError(
+        'Installed version of LevelDOWN ('
+      + leveldownVersion
+      + ') does not match required version ('
+      + requiredVersion
+      + ')'
+    )
+  }
+
+  try {
+    return leveldown = require('leveldown')
+  } catch (e) {
+    throw requireError(e)
+  }
+}
+
+function requireError (e) {
+  var template = 'Failed to require LevelDOWN (%s). Try `npm install leveldown` if it\'s missing'
+  return new LevelUPError(format(template, e.message))
+}
+
+module.exports = getLevelDOWN

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -26,7 +26,7 @@ var EventEmitter        = require('events').EventEmitter
 
   , getOptions          = util.getOptions
   , defaultOptions      = util.defaultOptions
-  , getLevelDOWN        = util.getLevelDOWN
+  , getLevelDOWN        = require('./leveldown')
   , dispatchError       = util.dispatchError
   , isDefined           = util.isDefined
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -5,8 +5,6 @@
  */
 
 var extend         = require('xtend')
-  , LevelUPError   = require('level-errors').LevelUPError
-  , format         = require('util').format
   , defaultOptions = {
         createIfMissing : true
       , errorIfExists   : false
@@ -15,49 +13,12 @@ var extend         = require('xtend')
       , compression     : true
     }
 
-  , leveldown
-
 function getOptions (options) {
   if (typeof options == 'string')
     options = { valueEncoding: options }
   if (typeof options != 'object')
     options = {}
   return options
-}
-
-function getLevelDOWN () {
-  if (leveldown)
-    return leveldown
-
-  var requiredVersion  = require('../package.json').devDependencies.leveldown
-    , leveldownVersion
-
-  try {
-    leveldownVersion = require('leveldown/package.json').version
-  } catch (e) {
-    throw requireError(e)
-  }
-
-  if (!require('semver').satisfies(leveldownVersion, requiredVersion)) {
-    throw new LevelUPError(
-        'Installed version of LevelDOWN ('
-      + leveldownVersion
-      + ') does not match required version ('
-      + requiredVersion
-      + ')'
-    )
-  }
-
-  try {
-    return leveldown = require('leveldown')
-  } catch (e) {
-    throw requireError(e)
-  }
-}
-
-function requireError (e) {
-  var template = 'Failed to require LevelDOWN (%s). Try `npm install leveldown` if it\'s missing'
-  return new LevelUPError(format(template, e.message))
 }
 
 function dispatchError (db, error, callback) {
@@ -71,7 +32,6 @@ function isDefined (v) {
 module.exports = {
     defaultOptions  : defaultOptions
   , getOptions      : getOptions
-  , getLevelDOWN    : getLevelDOWN
   , dispatchError   : dispatchError
   , isDefined       : isDefined
 }

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "tape": "~4.2.1"
   },
   "browser": {
+    "./lib/leveldown.js": false,
     "leveldown": false,
     "leveldown/package": false,
     "semver": false

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "async": "~1.5.0",
+    "browserify": "^14.3.0",
     "bustermove": "~1.0.0",
     "tap": "~2.3.1",
     "delayed": "~1.0.1",

--- a/test/browserify-test.js
+++ b/test/browserify-test.js
@@ -1,0 +1,29 @@
+/* Copyright (c) 2012-2016 LevelUP contributors
+ * See list at <https://github.com/level/levelup#contributing>
+ * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
+ */
+
+var common  = require('./common')
+
+  , assert  = require('referee').assert
+  , refute  = require('referee').refute
+  , buster  = require('bustermove')
+  , browserify = require('browserify')
+  , path = require('path')
+
+var PACKAGE_JSON = path.join(__dirname, '..', 'package.json')
+
+buster.testCase('Browserify Bundle', {
+  'does not contain package.json': function (done) {
+    var b = browserify(path.join(__dirname, '..'), {browserField: true})
+      .once('error', function (error) {
+        assert.fail(error)
+        done()
+      })
+    b.pipeline
+      .on('file', function (file, id, parent) {
+        refute.equals(file, PACKAGE_JSON)
+      })
+    b.bundle(done)
+  }
+})

--- a/test/optional-leveldown-test.js
+++ b/test/optional-leveldown-test.js
@@ -14,7 +14,7 @@ function clearCache () {
   delete require.cache[require.resolve('..')]
   delete require.cache[require.resolve('leveldown')]
   delete require.cache[require.resolve('leveldown/package')]
-  delete require.cache[require.resolve('../lib/util')]
+  delete require.cache[require.resolve('../lib/leveldown')]
 }
 
 buster.testCase('Optional LevelDOWN', {
@@ -22,8 +22,8 @@ buster.testCase('Optional LevelDOWN', {
   , 'tearDown': clearCache
 
   , 'test getLevelDOWN()': function () {
-      var util = require('../lib/util')
-      assert.same(util.getLevelDOWN(), require('leveldown'), 'correct leveldown provided')
+      var getLevelDOWN = require('../lib/leveldown')
+      assert.same(getLevelDOWN(), require('leveldown'), 'correct leveldown provided')
     }
 
   , 'test wrong version': function () {


### PR DESCRIPTION
Following on from #423.

This patch pulls the LevelDOWN loading and version checking code out of `lib/util.js` into its own, separate module.  It also modifies `package.json` to prevent Browserify from packing the new module, which in turn prevents it from packing the project's `package.json` file.

I mentioned a different approach in #423: Using a prepublish lifecycle script to extract `devDependencies.leveldown` into a one-line JSON file for the version checking code to `require`.  This modular approach seems cleaner, and leverages mechanisms, like the `browser` field, that `levelup` is already using.