### PR TITLE
fix: avoid calling getLevelDOWN if not present

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -30,6 +30,10 @@ var EventEmitter        = require('events').EventEmitter
   , dispatchError       = util.dispatchError
   , isDefined           = util.isDefined
 
+if (typeof getLevelDOWN !== 'function') {
+  getLevelDOWN = function noop () {}
+}
+
 function getCallback (options, callback) {
   return typeof options == 'function' ? options : callback
 }


### PR DESCRIPTION
Hi there!

This is the quick fix for the issue described on: https://github.com/Level/levelup/issues/426

I intended to come up with a full PR that would run tests in the browser as well, but due to the quantity and the fact that they rely on `fs`, I haven't been able to finish this quickly, you can see progress at https://github.com/diasdavid/levelup/tree/test/browser

Here is what I propose: Merge this PR and do a patch release so that no user hits this breakage when using it in the browser. After, finish browser testing so that this situation doesn't happen again.