### PR TITLE
fix: return noopnoop

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -31,7 +31,9 @@ var EventEmitter        = require('events').EventEmitter
   , isDefined           = util.isDefined
 
 if (typeof getLevelDOWN !== 'function') {
-  getLevelDOWN = function noop () {}
+  getLevelDOWN = function noop () {
+    return function noopnoop () {}
+  }
 }
 
 function getCallback (options, callback) {


### PR DESCRIPTION
Started getting ` TypeError: dbFactory is not a function` now because I missed understanding that getLevelDOWN should return a function.

It is a bit weird to me that the module requires calling that function in the first place if no options are passed nor levelDOWN exists.