### PR TITLE
throw more descriptive error if db factory is not a function

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -30,10 +30,6 @@ var EventEmitter        = require('events').EventEmitter
   , dispatchError       = util.dispatchError
   , isDefined           = util.isDefined
 
-if (typeof getLevelDOWN !== 'function') {
-  getLevelDOWN = function noop () {}
-}
-
 function getCallback (options, callback) {
   return typeof options == 'function' ? options : callback
 }

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -19,6 +19,7 @@ var EventEmitter        = require('events').EventEmitter
   , OpenError           = errors.OpenError
   , EncodingError       = errors.EncodingError
   , InitializationError = errors.InitializationError
+  , LevelUPError        = errors.LevelUPError
 
   , util                = require('./util')
   , Batch               = require('./batch')
@@ -108,11 +109,16 @@ LevelUP.prototype.open = function (callback) {
   }
 
   this.emit('opening')
-
   this._status = 'opening'
   this.db      = new DeferredLevelDOWN(this.location)
-  dbFactory    = this.options.db || getLevelDOWN()
-  db           = dbFactory(this.location)
+
+  if (typeof this.options.db !== 'function' &&
+      typeof getLevelDOWN !== 'function') {
+    throw new LevelUPError('missing db factory, you need to set options.db')
+  }
+
+  dbFactory = this.options.db || getLevelDOWN()
+  db = dbFactory(this.location)
 
   db.open(this.options, function (err) {
     if (err) {

--- a/package.json
+++ b/package.json
@@ -43,10 +43,11 @@
     "xtend": "~4.0.0"
   },
   "devDependencies": {
+    "after": "^0.8.2",
     "async": "~1.5.0",
+    "bl": "^1.2.1",
     "browserify": "^14.3.0",
     "bustermove": "~1.0.0",
-    "tap": "~2.3.1",
     "delayed": "~1.0.1",
     "faucet": "~0.0.1",
     "leveldown": "^1.1.0",
@@ -55,6 +56,7 @@
     "referee": "~1.2.0",
     "rimraf": "~2.4.3",
     "slow-stream": "0.0.4",
+    "tap": "~2.3.1",
     "tape": "~4.2.1"
   },
   "browser": {

--- a/test/browserify-test.js
+++ b/test/browserify-test.js
@@ -4,18 +4,20 @@
  */
 
 var common  = require('./common')
-
   , assert  = require('referee').assert
   , refute  = require('referee').refute
   , buster  = require('bustermove')
   , browserify = require('browserify')
   , path = require('path')
+  , after = require('after')
+  , bl = require('bl')
+  , spawn = require('child_process').spawn
 
 var PACKAGE_JSON = path.join(__dirname, '..', 'package.json')
 
 buster.testCase('Browserify Bundle', {
   'does not contain package.json': function (done) {
-    var b = browserify(path.join(__dirname, '..'), {browserField: true})
+    var b = browserify(path.join(__dirname, '..'), { browserField: true })
       .once('error', function (error) {
         assert.fail(error)
         done()
@@ -25,5 +27,28 @@ buster.testCase('Browserify Bundle', {
         refute.equals(file, PACKAGE_JSON)
       })
     b.bundle(done)
+  },
+  'throws error if missing db factory': function (done) {
+    var b = browserify(path.join(__dirname, 'data/browser-throws.js'), { browserField: true })
+    var node = spawn('node')
+    var fin = after(2, done)
+    node.stderr.pipe(bl(function (err, buf) {
+      assert.match(buf.toString(), /LevelUPError: missing db factory, you need to set options\.db/)
+      fin()
+    }))
+    node.on('exit', function (code) {
+      assert.equals(code, 1)
+      fin()
+    })
+    b.bundle().pipe(node.stdin)
+  },
+  'works with valid db factory (memdown)': function (done) {
+    var b = browserify(path.join(__dirname, 'data/browser-works.js'), { browserField: true })
+    var node = spawn('node')
+    node.on('exit', function (code) {
+      assert.equals(code, 0)
+      done()
+    })
+    b.bundle().pipe(node.stdin)
   }
 })

--- a/test/data/browser-throws.js
+++ b/test/data/browser-throws.js
@@ -1,0 +1,6 @@
+/* Copyright (c) 2012-2016 LevelUP contributors
+ * See list at <https://github.com/level/levelup#contributing>
+ * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
+ */
+
+require('../..')('some/path')

--- a/test/data/browser-works.js
+++ b/test/data/browser-works.js
@@ -1,0 +1,6 @@
+/* Copyright (c) 2012-2016 LevelUP contributors
+ * See list at <https://github.com/level/levelup#contributing>
+ * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
+ */
+
+require('../..')('some/path', { db: require('memdown') })


### PR DESCRIPTION
`options.db` _must_ be set when `levelup` is browserified, this patch makes it clearer if/when this happens

* undos https://github.com/Level/levelup/pull/427
* related https://github.com/Level/levelup/pull/424