### PR TITLE
feat: add typescript definitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ addons:
 
 before_install:
   - export JOBS=max
-
+  
 node_js:
   - '8'
   - '6'

--- a/lib/levelup.d.ts
+++ b/lib/levelup.d.ts
@@ -1,0 +1,104 @@
+import { EventEmitter } from 'events';
+import * as levelerrors from 'level-errors';
+
+interface LevelUp<
+  TPutOptions,
+  TGetOptions,
+  TDeleteOptions,
+  TBatchOptions,
+  > extends EventEmitter {
+  open(): Promise<void>;
+  open(callback?: (err: any) => any): void;
+
+  close(): Promise<void>;
+  close(callback?: (err: any) => any): void;
+
+  put(key: any, value: any, options?: TPutOptions): Promise<void>;
+  put(key: any, value: any, options?: TPutOptions, callback?: (err: any) => any): void;
+  put(key: any, value: any, callback?: (err: any) => any): void;
+
+  get(key: any, options?: TGetOptions): Promise<any>;
+  get(key: any, options?: TGetOptions, callback?: (err: any, value: any) => any): void;
+  get(key: any, callback?: (err: any, value: any) => any): void;
+
+  del(key: any, options?: TDeleteOptions): Promise<void>
+  del(key: any, options?: TDeleteOptions, callback?: (err: any) => any): void;
+  del(key: any, callback?: (err: any) => any): void;
+
+  batch(array: LevelUpBatch[], options?: TBatchOptions): Promise<void>;
+  batch(array: LevelUpBatch[], options?: TBatchOptions, callback?: (err?: any) => any): void;
+  batch(array: LevelUpBatch[], callback?: (err?: any) => any): void;
+
+  batch(): LevelUpChain<TPutOptions, TDeleteOptions>;
+
+  isOpen(): boolean;
+  isClosed(): boolean;
+
+  createReadStream(options?: ReadStreamOptions): NodeJS.ReadableStream;
+  createKeyStream(options?: StreamOptions): NodeJS.ReadableStream;
+  createValueStream(options?: StreamOptions): NodeJS.ReadableStream;
+
+  //emitted when a new value is 'put'
+  on(event: 'put', cb: (key: any, value: any) => void): this
+  /**emitted when a value is deleted*/
+  on(event: 'del', cb: (key: any) => void)
+  /**emitted when a batch operation has executed */
+  on(event: 'batch', cb: (ary: any[]) => void)
+  /**emitted when the database has opened ('open' is synonym) */
+  on(event: 'ready', cb: () => void)
+  /**emitted when the database has opened */
+  on(event: 'open', cb: () => void)
+  /** emitted when the database has closed*/
+  on(event: 'closed', cb: () => void)
+  /** emitted when the database is opening */
+  on(event: 'opening', cb: () => void)
+  /** emitted when the database is closing */
+  on(event: 'closing', cb: () => void)
+}
+
+interface StreamOptions {
+  gt?: any,
+  gte?: any,
+  lt?: any,
+  lte?: any,
+  reverse?: boolean,
+  limit?: number,
+}
+
+interface ReadStreamOptions extends StreamOptions {
+  keys?: boolean,
+  values?: boolean,
+}
+
+interface LevelUpChain<TPutOptions, TDeleteOptions> {
+  put(key: any, value: any, options?: TPutOptions): this;
+  del(key: any, options?: TDeleteOptions): this;
+  clear(): this;
+  write(callback?: (err?: any) => any): this;
+  write(): Promise<this>;
+}
+
+interface BatchDelete {
+  type: 'del',
+  key: any
+}
+
+interface BatchPut {
+  type: 'put',
+  key: any,
+  value: any,
+}
+
+type LevelUpBatch = BatchDelete | BatchPut
+
+declare namespace levelup {
+  export interface AbstractDown<TPut, TGet, TDelete, TBatch, TOptions> { }
+  export var errors: typeof levelerrors
+}
+
+declare function levelup<TPut, TGet, TDelete, TBatch, TOptions>(
+  db: levelup.AbstractDown<TPut, TGet, TDelete, TBatch, TOptions>,
+  options?: TOptions,
+  cb?: (err) => void): LevelUp<TPut, TGet, TDelete, TBatch>;
+
+export = levelup;

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -61,6 +61,8 @@ function LevelUP (db, options, callback) {
   this.open(callback)
 }
 
+LevelUP.prototype.emit = EventEmitter.prototype.emit
+LevelUP.prototype.once = EventEmitter.prototype.once
 inherits(LevelUP, EventEmitter)
 
 LevelUP.prototype.open = function (callback) {
@@ -288,5 +290,5 @@ function maybeError (db, callback) {
   }
 }
 
+LevelUP.errors = errors
 module.exports = LevelUP
-module.exports.errors = errors

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "Matteo Collina <matteo.collina@gmail.com> (https://github.com/mcollina)",
     "Pedro Teixeira <pedro.teixeira@gmail.com> (https://github.com/pgte)",
     "James Halliday <mail@substack.net> (https://github.com/substack)",
-    "Jarrett Cruger <jcrugzz@gmail.com> (https://github.com/jcrugzz)"
+    "Jarrett Cruger <jcrugzz@gmail.com> (https://github.com/jcrugzz)",
+    "Meirion Hughes <crakinshot@yahoo.com> (https://github.com/meirionhughes)"
   ],
   "repository": {
     "type": "git",
@@ -33,6 +34,7 @@
     "json"
   ],
   "main": "lib/levelup.js",
+  "typings": "lib/levelup.d.ts",
   "dependencies": {
     "deferred-leveldown": "~2.0.0",
     "level-errors": "~1.1.0",
@@ -40,6 +42,7 @@
     "xtend": "~4.0.0"
   },
   "devDependencies": {
+    "@types/node": "^8.0.26",
     "after": "^0.8.2",
     "async": "^2.5.0",
     "bl": "^1.2.1",
@@ -56,7 +59,9 @@
     "safe-buffer": "^5.1.0",
     "slow-stream": "0.0.4",
     "standard": "^10.0.2",
-    "tape": "^4.7.0"
+    "tape": "^4.7.0",
+    "ts-node": "^3.3.0",
+    "typescript": "^2.5.2"
   },
   "scripts": {
     "test": "standard && tape test/*-test.js | faucet"

--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -44,7 +44,7 @@ buster.testCase('ReadStream', {
     var pauseVerify = function () {
       assert.equals(calls, 5, 'stream should still be paused')
       rs.resume()
-      pauseVerify.called = true
+      pauseVerify['called'] = true
     }
     var onData = function () {
       if (++calls === 5) {
@@ -54,7 +54,7 @@ buster.testCase('ReadStream', {
     }
     var verify = function () {
       assert.equals(calls, this.sourceData.length, 'onData was used in test')
-      assert(pauseVerify.called, 'pauseVerify was used in test')
+      assert(pauseVerify['called'], 'pauseVerify was used in test')
       this.verify(rs, done)
     }.bind(this)
 

--- a/test/ts-test.js
+++ b/test/ts-test.js
@@ -1,0 +1,24 @@
+/* Copyright (c) 2012-2017 LevelUP contributors
+ * See list at <https://github.com/level/levelup#contributing>
+ * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
+ */
+const common = require('./common')
+const buster = require('bustermove')
+const execSync = require('child_process').execSync
+
+const thisFile = 'ts-test.js'
+const testFolder = './test/'
+const testCase = /-test.js/
+const fs = require('fs')
+
+buster.testCase('TypeScript', {
+  'tearDown': common.commonTearDown,
+  'test all through typescript': function (done) {
+    fs.readdirSync(testFolder)
+      .filter(x => testCase.test(x) && x.endsWith(thisFile) === false)
+      .forEach(file => {
+        execSync('ts-node ' + testFolder + file, { stdio: 'inherit' })
+      })
+    done()
+  }
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "module": "commonjs",
+    "moduleResolution": "node",       
+    "allowJs": true,
+    "checkJs": true,
+    "types": [
+      "node"
+    ]
+  }
+}


### PR DESCRIPTION
bit of a fiddly one this. basically it is typed to that you can argument the `abstract-leveldown` store type and then infer: 

* the options you need to pass through to levelup(store, ...) 
* the put, get, delete, batch options you use with levelup()

example typescript.  

```ts
import * as levelup from 'levelup';
import * as leveldown from 'leveldown';

let db = levelup(leveldown('./db'));

async function main() {
  await db.put("hello", new Buffer([1, 2, 3, 4]), );
  await db.get("hello", ).then(console.log);

  await db.batch()
    .put("foo", new Buffer([1]))
    .put("bar", new Buffer([2]))
    .put("ray", new Buffer([3]))
    .del("hello")
    .write();

  await new Promise(r => {
    db.createReadStream({
      limit: 2
    }).on("data", (data) => {
      console.log(data);
    }).on("end", r);
  });
}
```

* [ ] could do with a review to ensure you want to go this route the the type generics. 
* [ ] probably worth adding types to abstract-leveldown and using them here. 
* [x] add missing typings. i.e. levelup `errors` and double-check against docs 