### PR TITLE
feat: restore typings + testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   * <a href="#events">Events</a>
   * <a href="#extending">Extending LevelUP</a>
   * <a href="#multiproc">Multi-process access</a>
+  * <a href="#typings">TypeScript </a>
   * <a href="#support">Getting support</a>
   * <a href="#contributing">Contributing</a>
   * <a href="#license">Licence &amp; copyright</a>
@@ -474,6 +475,15 @@ Multi-process access
 Stores like LevelDB are thread-safe but they are **not** suitable for accessing with multiple processes. You should only ever have a store open from a single Node.js process. Node.js clusters are made up of multiple processes so a LevelUP instance cannot be shared between them either.
 
 See the <a href="https://github.com/level/levelup/wiki/Modules"><b>wiki</b></a> for some LevelUP extensions, including [multilevel](https://github.com/juliangruber/multilevel), that may help if you require a single store to be shared across processes.
+
+<a name="typings"></a>
+TypeScript 
+----------
+
+LevelUP comes with TypeScript definitions that can automatically infer options from a typed `abstract-leveldown` implementation. 
+
+See the <a href="https://github.com/Level/levelup/wiki/Typings"><b>wiki</b></a> for  more information. 
+
 
 <a name="support"></a>
 Getting support

--- a/lib/levelup.d.ts
+++ b/lib/levelup.d.ts
@@ -1,0 +1,96 @@
+import { EventEmitter } from 'events';
+import * as levelerrors from 'level-errors';
+import { AbstractLevelDOWN, AbstractIteratorOptions, Batch } from 'abstract-leveldown';
+
+declare global {
+  namespace Level {
+    export interface UP<K, V, O, PO, GO, DO, IO, BO, TB> {
+    }
+  }
+}
+
+export interface LevelUp<K=any, V=any, O={}, PO={}, GO={}, DO={}, IO={}, BO={}, TB=Batch<K, V>>
+  extends Level.UP<K, V, O, PO, GO, DO, IO, BO, TB>,
+  EventEmitter {
+
+  open(): Promise<void>;
+  open(callback?: (err: any) => any): void;
+  close(): Promise<void>;
+  close(callback?: (err: any) => any): void;
+
+  put(key: K, value: V, options?: PO): Promise<void>;
+  put(key: K, value: V, options: PO, callback: (err: any) => any): void;
+  put(key: K, value: V, callback: (err: any) => any): void;
+
+  get(key: K, options?: GO): Promise<any>;
+  get(key: K, options: GO, callback: (err: any, value: any) => any): void;
+  get(key: K, callback: (err: any, value: any) => any): void;
+
+  del(key: K, options?: DO): Promise<void>
+  del(key: K, options: DO, callback: (err: any) => any): void;
+  del(key: K, callback: (err: any) => any): void;
+
+  batch(array: TB[], options?: BO): Promise<void>;
+  batch(array: TB[], options: BO, callback: (err?: any) => any): void;
+  batch(array: TB[], callback: (err?: any) => any): void;
+
+  batch(): LevelUpChain<K, V>;
+
+  isOpen(): boolean;
+  isClosed(): boolean;
+
+  createReadStream(options?: IO & AbstractIteratorOptions<K>): NodeJS.ReadableStream;
+  createKeyStream(options?: IO & AbstractIteratorOptions<K>): NodeJS.ReadableStream;
+  createValueStream(options?: IO & AbstractIteratorOptions<K>): NodeJS.ReadableStream;
+
+  /**emitted when a new value is 'put' */
+  on(event: 'put', cb: (key: K, value: V) => void): this
+  /**emitted when a value is deleted*/
+  on(event: 'del', cb: (key: K) => void)
+  /**emitted when a batch operation has executed */
+  on(event: 'batch', cb: (ary: any[]) => void)
+  /**emitted when the database has opened ('open' is synonym) */
+  on(event: 'ready', cb: () => void)
+  /**emitted when the database has opened */
+  on(event: 'open', cb: () => void)
+  /** emitted when the database has closed*/
+  on(event: 'closed', cb: () => void)
+  /** emitted when the database is opening */
+  on(event: 'opening', cb: () => void)
+  /** emitted when the database is closing */
+  on(event: 'closing', cb: () => void)
+}
+
+interface LevelUpConstructor {
+  <K=any, V=any, O=any, PO={}, GO={}, DO={}, IO={}, BO={}, B = Batch<K, V>>(
+    db: AbstractLevelDOWN<any, any, O, PO, GO, DO, IO, BO>,
+    options: O,
+    cb?: (err: Error) => void): LevelUp<K, V, O, PO, GO, DO, IO, BO, B>;
+  <K=any, V=any, O=any, PO={}, GO={}, DO={}, IO={}, BO={}, B = Batch<K, V>>(
+    db: AbstractLevelDOWN<any, any, O, PO, GO, DO, IO, BO>,
+    cb?: (err: Error) => void): LevelUp<K, V, O, PO, GO, DO, IO, BO, B>;
+
+  new <K=any, V=any, O=any, PO={}, GO={}, DO={}, IO={}, BO={}, B = Batch<K, V>>(
+    db: AbstractLevelDOWN<any, any, O, PO, GO, DO, IO, BO>,
+    options: O,
+    cb?: (err?: Error) => void): LevelUp<K, V, O, PO, GO, DO, IO, BO, B>;
+  new <K=any, V=any, O=any, PO={}, GO={}, DO={}, IO={}, BO={}, B = Batch<K, V>>(
+    db: AbstractLevelDOWN<any, any, O, PO, GO, DO, IO, BO>,
+    cb?: (err?: Error) => void): LevelUp<K, V, O, PO, GO, DO, IO, BO, B>;
+
+  errors: typeof levelerrors;
+}
+
+export interface LevelUpChain<K=any, V=any> {
+  readonly length: number;
+  put(key: K, value: V): this;
+  del(key: K): this;
+  clear(): this;
+  write(callback: (err?: any) => any): this;
+  write(): Promise<this>;
+}
+
+export var errors: typeof levelerrors;
+
+declare const LevelUp: LevelUpConstructor;
+export default LevelUp

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "json"
   ],
   "main": "lib/levelup.js",
+  "typings": "lib/levelup.d.ts",
   "dependencies": {
     "deferred-leveldown": "~2.0.2",
     "level-errors": "~1.1.0",
@@ -41,27 +42,31 @@
     "xtend": "~4.0.0"
   },
   "devDependencies": {
-    "abstract-leveldown": "^2.7.0",
+    "@types/node": "^8.0.31",
+    "abstract-leveldown": "^2.7.1",
     "after": "^0.8.2",
     "async": "^2.5.0",
     "bl": "^1.2.1",
     "browserify": "^14.3.0",
     "bustermove": "~1.0.0",
     "delayed": "~1.0.1",
-    "encoding-down": "^2.2.0",
+    "encoding-down": "^2.3.1",
     "faucet": "~0.0.1",
     "leveldown": "^2.0.0",
-    "memdown": "^1.2.4",
+    "memdown": "^1.4.1",
     "msgpack-js": "~0.3.0",
     "referee": "~1.2.0",
     "rimraf": "^2.6.1",
     "safe-buffer": "^5.1.0",
     "slow-stream": "0.0.4",
     "standard": "^10.0.2",
-    "tape": "^4.7.0"
+    "tape": "^4.7.0",
+    "ts-node": "^3.3.0",
+    "typescript": "^2.5.2"
   },
   "scripts": {
-    "test": "standard && node test | faucet"
+    "test": "standard && node test | faucet && npm run ts-test",
+    "ts-test": "ts-node --no-cache test | faucet"
   },
   "engines": {
     "node": ">=6.0.0"

--- a/test/common.js
+++ b/test/common.js
@@ -12,11 +12,12 @@ var rimraf = require('rimraf')
 var fs = require('fs')
 var path = require('path')
 var delayed = require('delayed').delayed
-var levelup = require('../lib/levelup.js')
+
+var levelup = require('../lib/levelup.js').default
 var errors = require('level-errors')
 var dbidx = 0
-var leveldown = require('leveldown')
-var encDown = require('encoding-down')
+var leveldown = require('leveldown').default
+var encDown = require('encoding-down').default
 
 assert(levelup.errors === errors)
 

--- a/test/create-stream-vs-put-racecondition.js
+++ b/test/create-stream-vs-put-racecondition.js
@@ -3,7 +3,7 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
+var levelup = require('../lib/levelup.js').default
 var common = require('./common')
 var assert = require('referee').assert
 var buster = require('bustermove')

--- a/test/deferred-open-test.js
+++ b/test/deferred-open-test.js
@@ -3,9 +3,9 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
-var encDown = require('encoding-down')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
+var encDown = require('encoding-down').default
 var async = require('async')
 var common = require('./common')
 var assert = require('referee').assert

--- a/test/idempotent-test.js
+++ b/test/idempotent-test.js
@@ -3,8 +3,8 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
 var common = require('./common')
 var assert = require('referee').assert
 var buster = require('bustermove')

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -3,8 +3,8 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
 var common = require('./common')
 var assert = require('referee').assert
 var refute = require('referee').refute

--- a/test/inject-encoding-test.js
+++ b/test/inject-encoding-test.js
@@ -3,9 +3,9 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
-var encDown = require('encoding-down')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
+var encDown = require('encoding-down').default
 var async = require('async')
 var common = require('./common')
 var msgpack = require('msgpack-js')

--- a/test/json-test.js
+++ b/test/json-test.js
@@ -3,9 +3,9 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
-var encDown = require('encoding-down')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
+var encDown = require('encoding-down').default
 var async = require('async')
 var common = require('./common')
 var assert = require('referee').assert

--- a/test/leveldown-substitution-test.js
+++ b/test/leveldown-substitution-test.js
@@ -3,12 +3,12 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
+var levelup = require('../lib/levelup.js').default
 var assert = require('referee').assert
 var refute = require('referee').refute
 var buster = require('bustermove')
-var memdown = require('memdown')
-var encDown = require('encoding-down')
+var memdown = require('memdown').default
+var encDown = require('encoding-down').default
 
 require('./common')
 

--- a/test/null-and-undefined-test.js
+++ b/test/null-and-undefined-test.js
@@ -3,9 +3,9 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
-var errors = levelup.errors
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
+var errors = require('../lib/levelup.js').errors
 var common = require('./common')
 var assert = require('referee').assert
 var refute = require('referee').refute

--- a/test/open-patchsafe-test.js
+++ b/test/open-patchsafe-test.js
@@ -3,8 +3,8 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
 var common = require('./common')
 var assert = require('referee').assert
 var refute = require('referee').refute

--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -3,9 +3,9 @@
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
 
-var levelup = require('../lib/levelup.js')
-var leveldown = require('leveldown')
-var encDown = require('encoding-down')
+var levelup = require('../lib/levelup.js').default
+var leveldown = require('leveldown').default
+var encDown = require('encoding-down').default
 var common = require('./common')
 var SlowStream = require('slow-stream')
 var delayed = require('delayed')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "es2015",
+    "moduleResolution": "node",
+    "checkJs": true,
+    "allowJs": true
+  }
+}


### PR DESCRIPTION
* to start discussion and review of adding typings back into master
* keen eye will notice imports for tests are using `.default` for some level stuff. This is because the typescript compiler will complain because those repositories now have es2015 default exports.
