### PR TITLE
restoring node 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,4 @@ before_install:
 node_js:
   - '8'
   - '6'
+  - '4'

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -58,7 +58,10 @@ Batch.prototype.write = function (callback) {
   var ops = this.ops
   var promise
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   try {
     this.batch.write(function (err) {

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -69,7 +69,10 @@ LevelUP.prototype.open = function (callback) {
   var self = this
   var promise
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   if (this.isOpen()) {
     process.nextTick(callback, null, self)
@@ -100,7 +103,10 @@ LevelUP.prototype.close = function (callback) {
   var self = this
   var promise
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   if (this.isOpen()) {
     this.db.close(function () {
@@ -143,7 +149,10 @@ LevelUP.prototype.get = function (key, options, callback) {
 
   callback = getCallback(options, callback)
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   if (maybeError(this, callback)) { return promise }
 
@@ -174,7 +183,10 @@ LevelUP.prototype.put = function (key, value, options, callback) {
 
   callback = getCallback(options, callback)
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   if (maybeError(this, callback)) { return promise }
 
@@ -201,7 +213,10 @@ LevelUP.prototype.del = function (key, options, callback) {
 
   callback = getCallback(options, callback)
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   if (maybeError(this, callback)) { return promise }
 
@@ -232,7 +247,10 @@ LevelUP.prototype.batch = function (arr, options, callback) {
 
   callback = getCallback(options, callback)
 
-  if (!callback) [ callback, promise ] = promisify()
+  if (!callback) {
+    callback = promisify()
+    promise = callback.promise
+  }
 
   if (maybeError(this, callback)) { return promise }
 

--- a/lib/promisify.js
+++ b/lib/promisify.js
@@ -12,7 +12,8 @@ function promisify () {
       else resolve(value)
     }
   })
-  return [ callback, promise ]
+  callback.promise = promise
+  return callback
 }
 
 module.exports = promisify

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "test": "standard && node test | faucet"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=4.0.0"
   },
   "license": "MIT"
 }

--- a/test/maybe-error-test.js
+++ b/test/maybe-error-test.js
@@ -2,6 +2,7 @@
  * See list at <https://github.com/level/levelup#contributing>
  * MIT License <https://github.com/level/levelup/blob/master/LICENSE.md>
  */
+'use strict'
 
 var common = require('./common')
 var assert = require('referee').assert


### PR DESCRIPTION
This is for issue #516

I believe the node version badge will update on next release since it’s based on package.json engines field.