### PR TITLE
improve 'must provide db' error message to make it clearer

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -46,7 +46,7 @@ function LevelUP (db, options, callback) {
   options = options || {}
 
   if (!db || typeof db !== 'object') {
-    error = new InitializationError('The first `db` argument must be an abstract-leveldown compliant store')
+    error = new InitializationError('First argument must be an abstract-leveldown compliant store')
     if (typeof callback === 'function') {
       return process.nextTick(callback, error)
     }

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -46,7 +46,7 @@ function LevelUP (db, options, callback) {
   options = options || {}
 
   if (!db || typeof db !== 'object') {
-    error = new InitializationError('Must provide db')
+    error = new InitializationError('The first `db` argument must be an abstract-leveldown compliant store')
     if (typeof callback === 'function') {
       return process.nextTick(callback, error)
     }

--- a/test/browserify-test.js
+++ b/test/browserify-test.js
@@ -32,7 +32,7 @@ buster.testCase('Browserify Bundle', {
     var fin = after(2, done)
     node.stderr.pipe(bl(function (err, buf) {
       refute(err)
-      assert.match(buf.toString(), /InitializationError: Must provide db/)
+      assert.match(buf.toString(), /InitializationError: The first `db` argument must be an abstract-leveldown compliant store/)
       fin()
     }))
     node.on('exit', function (code) {

--- a/test/browserify-test.js
+++ b/test/browserify-test.js
@@ -32,7 +32,7 @@ buster.testCase('Browserify Bundle', {
     var fin = after(2, done)
     node.stderr.pipe(bl(function (err, buf) {
       refute(err)
-      assert.match(buf.toString(), /InitializationError: The first `db` argument must be an abstract-leveldown compliant store/)
+      assert.match(buf.toString(), /InitializationError: First argument must be an abstract-leveldown compliant store/)
       fin()
     }))
     node.on('exit', function (code) {


### PR DESCRIPTION
As mentioned on #524 - I changed it to make the error message clearer.

Previously was **must provide db**,
changed to **The first `db` argument must be an abstract-leveldown compliant store**.