### PR TITLE
Call rs.destroy() without using .bind()

### DIFF
--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -602,7 +602,9 @@ buster.testCase('ReadStream', {
       db.batch(data, function (err) {
         refute(!!err)
         var rs = db.createReadStream().on('close', done)
-        rs.once('data', rs.destroy.bind(rs))
+        rs.once('data', function () {
+          rs.destroy()
+        })
       })
     })
   },


### PR DESCRIPTION
See https://github.com/Level/levelup/issues/595#issuecomment-401153446