### PR TITLE
Support options passed to .open

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ db.get('foo', function (err, value) {
 
 <a name="open"></a>
 
-### `db.open([callback])`
+### `db.open([options][, callback])`
 
 Opens the underlying store. In general you should never need to call this method directly as it's automatically called by <a href="#ctor"><code>levelup()</code></a>.
 

--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -61,13 +61,22 @@ LevelUP.prototype.emit = EventEmitter.prototype.emit
 LevelUP.prototype.once = EventEmitter.prototype.once
 inherits(LevelUP, EventEmitter)
 
-LevelUP.prototype.open = function (callback) {
+LevelUP.prototype.open = function (opts, callback) {
   var self = this
   var promise
+
+  if (typeof opts === 'function') {
+    callback = opts
+    opts = null
+  }
 
   if (!callback) {
     callback = promisify()
     promise = callback.promise
+  }
+
+  if (!opts) {
+    opts = this.options
   }
 
   if (this.isOpen()) {
@@ -82,7 +91,7 @@ LevelUP.prototype.open = function (callback) {
 
   this.emit('opening')
 
-  this.db.open(this.options, function (err) {
+  this.db.open(opts, function (err) {
     if (err) {
       return callback(new OpenError(err))
     }

--- a/test/init-test.js
+++ b/test/init-test.js
@@ -58,5 +58,24 @@ buster.testCase('Init & open()', {
       return done()
     }
     throw new Error('did not throw')
+  },
+
+  'support open options': function (done) {
+    var down = memdown()
+
+    levelup(down, (err, up) => {
+      refute(err, 'no error')
+
+      up.close(() => {
+        down.open = (opts) => {
+          assert.equals(opts.foo, 'bar')
+          done()
+        }
+
+        up.open({
+          foo: 'bar'
+        })
+      })
+    })
   }
 })


### PR DESCRIPTION
LevelDown supports an [optional `options` argument](https://github.com/Level/abstract-leveldown#dbopenoptions-callback) passed the `db.open` method.  Currently LevelUp fails if options are passed to `.open` as it tries to invoke them as the callback so this PR adds support for that.

By and large you don't call `.open` directly but if you do (or an intermediate module does as in my case) LevelUp should probably honour the api.