### PR TITLE
Create test suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ libpeerconnection.log
 yarn.lock
 package-lock.json
 .nyc_output/
+airtap.log

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@ test
 .travis.yml
 .dntrc
 .nyc_output/
+airtap.log

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "standard && hallmark && (nyc -s node test/self.js | faucet) && nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "test-browsers": "airtap --loopback airtap.local test/self.js",
+    "test-browsers": "airtap --loopback airtap.local test/self.js > airtap.log",
     "test-browser-local": "airtap --local test/self.js",
     "hallmark": "hallmark --fix",
     "dependency-check": "dependency-check . test/*.js",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "license": "MIT",
   "main": "lib/levelup.js",
   "scripts": {
-    "test": "standard && hallmark && (nyc -s node test | faucet) && nyc report",
+    "test": "standard && hallmark && (nyc -s node test/self.js | faucet) && nyc report",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "test-browsers": "airtap --loopback airtap.local test/index.js",
-    "test-browser-local": "airtap --local test/index.js",
+    "test-browsers": "airtap --loopback airtap.local test/self.js",
+    "test-browser-local": "airtap --local test/self.js",
     "hallmark": "hallmark --fix",
     "dependency-check": "dependency-check . test/*.js",
     "prepublishOnly": "npm run dependency-check"

--- a/test/batch-test.js
+++ b/test/batch-test.js
@@ -15,7 +15,7 @@ module.exports = function (test, testCommon) {
         t.ifError(err)
 
         each(['foo', 'bar', 'baz'], function (key, next) {
-          db.get(key, function (err, value) {
+          db.get(key, { asBuffer: false }, function (err, value) {
             t.ifError(err)
             t.is(value, 'a' + key + 'value')
             next()
@@ -25,7 +25,7 @@ module.exports = function (test, testCommon) {
     })
   })
 
-  test('array-form batch(): promise interface', function (t) {
+  testCommon.promises && test('array-form batch(): promise interface', function (t) {
     discardable(t, testCommon, function (db, done) {
       db.batch([
         { type: 'put', key: 'foo', value: 'afoovalue' },
@@ -34,7 +34,7 @@ module.exports = function (test, testCommon) {
       ])
         .then(function () {
           each(['foo', 'bar', 'baz'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               t.ifError(err)
               t.is(value, 'a' + key + 'value')
               next()
@@ -67,7 +67,7 @@ module.exports = function (test, testCommon) {
         function (next) {
           // these should exist
           each(['2', '3', 'bar', 'baz'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               t.ifError(err)
               t.ok(value != null)
               next()
@@ -77,7 +77,7 @@ module.exports = function (test, testCommon) {
         function (next) {
           // these shouldn't exist
           each(['1', 'foo'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               t.ok(err)
               t.ok(err instanceof errors.NotFoundError)
               t.is(value, undefined)
@@ -107,7 +107,7 @@ module.exports = function (test, testCommon) {
             t.ifError(err)
 
             each(['one', 'three', '1', '2', '3'], function (key, next) {
-              db.get(key, function (err) {
+              db.get(key, { asBuffer: false }, function (err) {
                 if (['one', 'three', '1', '3'].indexOf(key) > -1) {
                   t.ok(err)
                 } else {
@@ -125,9 +125,11 @@ module.exports = function (test, testCommon) {
   test('chained batch(): options', function (t) {
     discardable(t, testCommon, function (db, done) {
       var batch = db.batch()
+      var underlying = batch
+      while (underlying.batch) underlying = underlying.batch
 
-      var write = batch.batch.write.bind(batch.batch)
-      batch.batch.write = function (options, cb) {
+      var write = underlying.write.bind(underlying)
+      underlying.write = function (options, cb) {
         t.same(options, { foo: 'bar' })
         write(options, cb)
       }
@@ -140,7 +142,7 @@ module.exports = function (test, testCommon) {
     })
   })
 
-  test('chained batch(): promise interface - options', function (t) {
+  testCommon.promises && test('chained batch(): promise interface - options', function (t) {
     discardable(t, testCommon, function (db, done) {
       var batch = db.batch()
 
@@ -157,7 +159,7 @@ module.exports = function (test, testCommon) {
     })
   })
 
-  test('chained batch(): promise interface', function (t) {
+  testCommon.promises && test('chained batch(): promise interface', function (t) {
     discardable(t, testCommon, function (db, done) {
       db.put('1', 'one', function (err) {
         t.ifError(err)
@@ -174,7 +176,7 @@ module.exports = function (test, testCommon) {
           .write()
           .then(function () {
             each(['one', 'three', '1', '2', '3'], function (key, next) {
-              db.get(key, function (err) {
+              db.get(key, { asBuffer: false }, function (err) {
                 if (['one', 'three', '1', '3'].indexOf(key) > -1) {
                   t.ok(err)
                 } else {
@@ -228,7 +230,7 @@ module.exports = function (test, testCommon) {
         function (next) {
           // these should exist
           each(['2', '3', 'bar', 'baz'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               t.ifError(err)
               t.ok(value != null)
               next()
@@ -238,7 +240,7 @@ module.exports = function (test, testCommon) {
         function (next) {
           // these shouldn't exist
           each(['1', 'foo'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               t.ok(err)
               t.ok(err instanceof errors.NotFoundError)
               t.is(value, undefined)
@@ -264,7 +266,7 @@ module.exports = function (test, testCommon) {
         function (next) {
           // these should exist
           each(['2', '3'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               t.ifError(err)
               t.ok(value != null)
               next()
@@ -273,7 +275,7 @@ module.exports = function (test, testCommon) {
         },
         function (next) {
           // this shouldn't exist
-          db.get('1', function (err, value) {
+          db.get('1', { asBuffer: false }, function (err, value) {
             t.ok(err)
             t.ok(err instanceof errors.NotFoundError)
             t.is(value, undefined)

--- a/test/get-put-del-test.js
+++ b/test/get-put-del-test.js
@@ -37,7 +37,7 @@ module.exports = function (test, testCommon) {
     discardable(t, testCommon, function (db, done) {
       db.put('some key', 'some value stored in the database', function (err) {
         t.ifError(err)
-        db.get('some key', function (err, value) {
+        db.get('some key', { asBuffer: false }, function (err, value) {
           t.ifError(err)
           t.is(value, 'some value stored in the database')
           done()
@@ -50,7 +50,7 @@ module.exports = function (test, testCommon) {
     discardable(t, testCommon, function (db, done) {
       db.put('some key', 'some value stored in the database')
         .then(function () {
-          return db.get('some key')
+          return db.get('some key', { asBuffer: false })
         })
         .then(function (value) {
           t.is(value, 'some value stored in the database')
@@ -90,7 +90,7 @@ module.exports = function (test, testCommon) {
         },
         function (next) {
           each(['foo', 'bar', 'baz'], function (key, next) {
-            db.get(key, function (err, value) {
+            db.get(key, { asBuffer: false }, function (err, value) {
               // we should get foo & baz but not bar
               if (key === 'bar') {
                 t.ok(err)

--- a/test/index.js
+++ b/test/index.js
@@ -1,46 +1,32 @@
-// Promise polyfill for IE and others.
-if (process.browser && typeof Promise !== 'function') {
-  global.Promise = require('pinkie')
+'use strict'
+
+var common = require('./common')
+
+function suite (options) {
+  var testCommon = common(options)
+  var test = testCommon.test
+
+  require('./argument-checking-test')(test, testCommon)
+  require('./batch-test')(test, testCommon)
+  if (testCommon.encodings) require('./binary-test')(test, testCommon)
+  if (testCommon.clear) require('./clear-test')(test)
+  if (testCommon.snapshots) require('./create-stream-vs-put-racecondition')(test, testCommon)
+  if (testCommon.deferredOpen) require('./deferred-open-test')(test, testCommon)
+  require('./get-put-del-test')(test, testCommon)
+  require('./idempotent-test')(test, testCommon)
+  require('./init-test')(test, testCommon)
+  if (testCommon.encodings) require('./custom-encoding-test')(test, testCommon)
+  if (testCommon.encodings) require('./json-encoding-test')(test, testCommon)
+  if (testCommon.streams) require('./key-value-streams-test')(test, testCommon)
+  require('./maybe-error-test')(test, testCommon)
+  require('./no-encoding-test')(test, testCommon)
+  require('./null-and-undefined-test')(test, testCommon)
+  if (testCommon.deferredOpen) require('./open-patchsafe-test')(test, testCommon)
+  if (testCommon.streams) require('./read-stream-test')(test, testCommon)
+  if (testCommon.snapshots) require('./snapshot-test')(test, testCommon)
+  require('./iterator-test')(test, testCommon)
+  if (testCommon.seek) require('./iterator-seek-test')(test, testCommon)
 }
 
-var test = require('tape')
-var memdown = require('memdown')
-var encode = require('encoding-down')
-var levelup = require('../lib/levelup')
-
-var testCommon = require('./common')({
-  test: test,
-  factory: function (options) {
-    return levelup(encode(memdown(), options))
-  },
-  clear: true,
-  deferredOpen: true,
-  promises: true,
-  streams: true,
-  encodings: true
-})
-
-require('./argument-checking-test')(test, testCommon)
-require('./batch-test')(test, testCommon)
-if (testCommon.encodings) require('./binary-test')(test, testCommon)
-if (testCommon.clear) require('./clear-test')(test)
-if (testCommon.snapshots) require('./create-stream-vs-put-racecondition')(test, testCommon)
-if (testCommon.deferredOpen) require('./deferred-open-test')(test, testCommon)
-require('./get-put-del-test')(test, testCommon)
-require('./idempotent-test')(test, testCommon)
-require('./init-test')(test, testCommon)
-if (testCommon.encodings) require('./custom-encoding-test')(test, testCommon)
-if (testCommon.encodings) require('./json-encoding-test')(test, testCommon)
-if (testCommon.streams) require('./key-value-streams-test')(test, testCommon)
-require('./maybe-error-test')(test, testCommon)
-require('./no-encoding-test')(test, testCommon)
-require('./null-and-undefined-test')(test, testCommon)
-if (testCommon.deferredOpen) require('./open-patchsafe-test')(test, testCommon)
-if (testCommon.streams) require('./read-stream-test')(test, testCommon)
-if (testCommon.snapshots) require('./snapshot-test')(test, testCommon)
-require('./iterator-test')(test, testCommon)
-if (testCommon.seek) require('./iterator-seek-test')(test, testCommon)
-
-if (!process.browser) {
-  require('./browserify-test')(test)
-}
+suite.common = common
+module.exports = suite

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,7 @@ function suite (options) {
   require('./null-and-undefined-test')(test, testCommon)
   if (testCommon.deferredOpen) require('./open-patchsafe-test')(test, testCommon)
   if (testCommon.streams) require('./read-stream-test')(test, testCommon)
-  if (testCommon.snapshots) require('./snapshot-test')(test, testCommon)
+  if (testCommon.snapshots && testCommon.streams) require('./snapshot-test')(test, testCommon)
   require('./iterator-test')(test, testCommon)
   if (testCommon.seek) require('./iterator-seek-test')(test, testCommon)
 }

--- a/test/read-stream-test.js
+++ b/test/read-stream-test.js
@@ -2,8 +2,11 @@ var sinon = require('sinon')
 var bigBlob = Array.apply(null, Array(1024 * 100)).map(function () { return 'aaaaaaaaaa' }).join('')
 var discardable = require('./util/discardable')
 var readStreamContext = require('./util/rs-context')
+var rsFactory = require('./util/rs-factory')
 
 module.exports = function (test, testCommon) {
+  var createReadStream = rsFactory(testCommon)
+
   function makeTest (fn) {
     return function (t) {
       discardable(t, testCommon, function (db, done) {
@@ -16,7 +19,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream()
+      var rs = createReadStream(db)
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -47,7 +50,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      rs = db.createReadStream()
+      rs = createReadStream(db)
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('end', function () {
@@ -63,7 +66,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream()
+      var rs = createReadStream(db)
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -79,7 +82,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream()
+      var rs = createReadStream(db)
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -94,7 +97,7 @@ module.exports = function (test, testCommon) {
       t.ifError(err)
       db.close(function (err) {
         t.ifError(err)
-        var rs = db.createReadStream()
+        var rs = createReadStream(db)
         rs.destroy()
         done()
       })
@@ -105,7 +108,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream()
+      var rs = createReadStream(db)
       rs.on('data', function () {
         rs.destroy()
         rs.destroy()
@@ -118,7 +121,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream()
+      var rs = createReadStream(db)
       var endSpy = sinon.spy()
       var calls = 0
       ctx.dataSpy = sinon.spy(function () {
@@ -152,7 +155,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ reverse: true })
+      var rs = createReadStream(db, { reverse: true })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -166,7 +169,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: '50' })
+      var rs = createReadStream(db, { start: '50' })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -181,7 +184,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: '50', reverse: true })
+      var rs = createReadStream(db, { start: '50', reverse: true })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -197,7 +200,7 @@ module.exports = function (test, testCommon) {
       t.ifError(err)
 
       // '49.5' doesn't actually exist but we expect it to start at '50' because '49' < '49.5' < '50' (in string terms as well as numeric)
-      var rs = db.createReadStream({ start: '49.5' })
+      var rs = createReadStream(db, { start: '49.5' })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -212,7 +215,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: '49.5', reverse: true })
+      var rs = createReadStream(db, { start: '49.5', reverse: true })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -229,7 +232,7 @@ module.exports = function (test, testCommon) {
 
       // '499999' doesn't actually exist but we expect it to start at '50' because '49' < '499999' < '50' (in string terms)
       // the same as the previous test but we're relying solely on string ordering
-      var rs = db.createReadStream({ start: '499999' })
+      var rs = createReadStream(db, { start: '499999' })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -244,7 +247,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: '50' })
+      var rs = createReadStream(db, { end: '50' })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -259,7 +262,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: '50.5' })
+      var rs = createReadStream(db, { end: '50.5' })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -274,7 +277,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: '50555555' })
+      var rs = createReadStream(db, { end: '50555555' })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -289,7 +292,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: '50.5', reverse: true })
+      var rs = createReadStream(db, { end: '50.5', reverse: true })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -303,7 +306,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: 30, end: 70 })
+      var rs = createReadStream(db, { start: 30, end: 70 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -318,7 +321,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: 70, end: 30, reverse: true })
+      var rs = createReadStream(db, { start: 70, end: 30, reverse: true })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -339,7 +342,7 @@ module.exports = function (test, testCommon) {
     db.batch(data.slice(), options, function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream(options)
+      var rs = createReadStream(db, options)
       rs.on('data', function (data) {
         t.is(data.value, 'abcdef0123456789')
       })
@@ -352,10 +355,10 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
       // read in reverse, assume all's good
-      var rs = db.createReadStream({ reverse: true })
+      var rs = createReadStream(db, { reverse: true })
       rs.on('close', function () {
         // now try reading the other way
-        var rs = db.createReadStream()
+        var rs = createReadStream(db)
         rs.on('data', ctx.dataSpy)
         rs.on('end', ctx.endSpy)
         rs.on('close', function () {
@@ -371,7 +374,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: 0 })
+      var rs = createReadStream(db, { start: 0 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -387,7 +390,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: 0 })
+      var rs = createReadStream(db, { end: 0 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -419,7 +422,7 @@ module.exports = function (test, testCommon) {
         t.is(db.isOpen(), false)
         t.is(db.isClosed(), false)
 
-        var rs = db.createReadStream()
+        var rs = createReadStream(db)
         rs.on('data', ctx.dataSpy)
         rs.on('end', ctx.endSpy)
         rs.on('close', function () {
@@ -437,7 +440,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ limit: 20 })
+      var rs = createReadStream(db, { limit: 20 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -451,7 +454,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ start: '20', limit: 20 })
+      var rs = createReadStream(db, { start: '20', limit: 20 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -465,7 +468,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: '50', limit: 20 })
+      var rs = createReadStream(db, { end: '50', limit: 20 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -479,7 +482,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream({ end: '30', limit: 50 })
+      var rs = createReadStream(db, { end: '30', limit: 50 })
       rs.on('data', ctx.dataSpy)
       rs.on('end', ctx.endSpy)
       rs.on('close', function () {
@@ -505,7 +508,7 @@ module.exports = function (test, testCommon) {
 
     db.batch(data, function (err) {
       t.ifError(err)
-      var rs = db.createReadStream().on('close', done)
+      var rs = createReadStream(db).on('close', done)
       rs.once('data', function () {
         rs.destroy()
       })
@@ -516,7 +519,7 @@ module.exports = function (test, testCommon) {
     db.batch(ctx.sourceData.slice(), function (err) {
       t.ifError(err)
 
-      var rs = db.createReadStream()
+      var rs = createReadStream(db)
         .on('close', done)
 
       process.nextTick(function () {

--- a/test/self.js
+++ b/test/self.js
@@ -10,6 +10,7 @@ var memdown = require('memdown')
 var encode = require('encoding-down')
 var levelup = require('../lib/levelup')
 var suite = require('.')
+var noop = function () {}
 
 suite({
   test: test,
@@ -21,6 +22,34 @@ suite({
   promises: true,
   streams: true,
   encodings: true
+})
+
+suite({
+  test: test,
+  factory: function (options) {
+    return levelup(memdown(), options)
+  },
+  clear: true,
+  deferredOpen: true,
+  promises: true,
+  streams: true,
+  encodings: false
+})
+
+// TODO to make this pass:
+// - Have abstract-leveldown use level-errors
+// - Perform type checks in same order (e.g. check key before callback)
+// - Add db.isClosed(), isOpen() to abstract-leveldown
+suite({
+  test: noop,
+  factory: function (options) {
+    return memdown()
+  },
+  clear: true,
+  deferredOpen: false,
+  promises: false,
+  streams: false,
+  encodings: false
 })
 
 if (!process.browser) {

--- a/test/self.js
+++ b/test/self.js
@@ -1,0 +1,28 @@
+'use strict'
+
+// Promise polyfill for IE and others.
+if (process.browser && typeof Promise !== 'function') {
+  global.Promise = require('pinkie')
+}
+
+var test = require('tape')
+var memdown = require('memdown')
+var encode = require('encoding-down')
+var levelup = require('../lib/levelup')
+var suite = require('.')
+
+suite({
+  test: test,
+  factory: function (options) {
+    return levelup(encode(memdown(), options))
+  },
+  clear: true,
+  deferredOpen: true,
+  promises: true,
+  streams: true,
+  encodings: true
+})
+
+if (!process.browser) {
+  require('./browserify-test')(test)
+}

--- a/test/snapshot-test.js
+++ b/test/snapshot-test.js
@@ -2,8 +2,11 @@ var delayed = require('delayed').delayed
 var trickle = require('trickle')
 var discardable = require('./util/discardable')
 var readStreamContext = require('./util/rs-context')
+var rsFactory = require('./util/rs-factory')
 
 module.exports = function (test, testCommon) {
+  var createReadStream = rsFactory(testCommon)
+
   test('ReadStream implicit snapshot', function (t) {
     discardable(t, testCommon, function (db, done) {
       var ctx = readStreamContext(t)
@@ -16,7 +19,7 @@ module.exports = function (test, testCommon) {
         //    to make *sure* that we're going to be reading it for longer than it
         //    takes to overwrite the data in there.
 
-        var rs = db.readStream().pipe(trickle({ interval: 5 }))
+        var rs = createReadStream(db).pipe(trickle({ interval: 5 }))
 
         rs.on('data', ctx.dataSpy)
         rs.once('end', ctx.endSpy)

--- a/test/util/rs-factory.js
+++ b/test/util/rs-factory.js
@@ -1,0 +1,16 @@
+'use strict'
+
+var xtend = require('xtend')
+
+module.exports = function (testCommon) {
+  return function createReadStream (db, options) {
+    if (!testCommon.encodings) {
+      options = xtend(options, {
+        keyAsBuffer: false,
+        valueAsBuffer: false
+      })
+    }
+
+    return db.createReadStream(options)
+  }
+}


### PR DESCRIPTION
Closes #273. Doesn't fully achieve what that ticket describes (being able to call the test suite externally would require moving devDependencies to dependencies, or moving the whole thing to its own module), but there's no use case for that anymore. So, this PR is more about being able to reuse the test suite _internally_. This allows us to test feature parity between `levelup` and `abstract-leveldown` (https://github.com/Level/community/issues/58).