### PR TITLE
chore: remove use of assert module

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -7,7 +7,6 @@ const IteratorStream = require('level-iterator-stream')
 const Batch = require('./batch')
 const errors = require('level-errors')
 const supports = require('level-supports')
-const assert = require('assert')
 const catering = require('catering')
 const getCallback = require('./common').getCallback
 const getOptions = require('./common').getOptions
@@ -54,7 +53,9 @@ function LevelUP (db, options, callback) {
     throw error
   }
 
-  assert.strictEqual(typeof db.status, 'string', '.status required, old abstract-leveldown')
+  if (typeof db.status !== 'string') {
+    throw new Error('.status required, old abstract-leveldown')
+  }
 
   this.options = getOptions(options)
   this._db = db


### PR DESCRIPTION
It's a node core module that isn't declared as a dep of this module so modules depending on this one have to declare it separately when using bundlers that don't polyfill node core.

Usage of it here seems unnecessary and can be replaced with a simple equality check.