### PR TITLE
refactor: use `github.com/isaacs/inherits` instead of `util`

### DIFF
--- a/lib/levelup.js
+++ b/lib/levelup.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const EventEmitter = require('events').EventEmitter
-const inherits = require('util').inherits
+const inherits = require('inherits')
 const DeferredLevelDOWN = require('deferred-leveldown')
 const IteratorStream = require('level-iterator-stream')
 const Batch = require('./batch')

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "catering": "^2.0.0",
     "deferred-leveldown": "^7.0.0",
+    "inherits": "^2.0.4",
     "level-errors": "^3.0.1",
     "level-iterator-stream": "^5.0.0",
     "level-supports": "^2.0.1",


### PR DESCRIPTION
Running into `Uncaught TypeError: inherits is not a function` in a project without a polyfill for `util`. https://github.com/Level/memdown uses the same dependency.